### PR TITLE
Remove NotNull in geoTaxonomies when submit onboarding

### DIFF
--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImpl.java
@@ -105,8 +105,11 @@ class PartyConnectorImpl implements PartyConnector {
         institutionUpdate.setZipCode(onboardingData.getInstitutionUpdate().getZipCode());
         institutionUpdate.setPaymentServiceProvider(onboardingData.getInstitutionUpdate().getPaymentServiceProvider());
         institutionUpdate.setDataProtectionOfficer(onboardingData.getInstitutionUpdate().getDataProtectionOfficer());
-        institutionUpdate.setGeographicTaxonomyCodes(onboardingData.getInstitutionUpdate().getGeographicTaxonomies().stream()
-                .map(GeographicTaxonomy::getCode).collect(Collectors.toList()));
+
+        if(Objects.nonNull(onboardingData.getInstitutionUpdate()) && Objects.nonNull(onboardingData.getInstitutionUpdate().getGeographicTaxonomies())) {
+            institutionUpdate.setGeographicTaxonomyCodes(onboardingData.getInstitutionUpdate().getGeographicTaxonomies().stream()
+                    .map(GeographicTaxonomy::getCode).collect(Collectors.toList()));
+        }
         institutionUpdate.setRea(onboardingData.getInstitutionUpdate().getRea());
         institutionUpdate.setShareCapital(onboardingData.getInstitutionUpdate().getShareCapital());
         institutionUpdate.setBusinessRegisterPlace(onboardingData.getInstitutionUpdate().getBusinessRegisterPlace());

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImplTest.java
@@ -109,12 +109,12 @@ class PartyConnectorImplTest {
     }
 
     @Test
-    void onboardingOrganization_emptyGeographicTaxonomies() {
+    void onboardingOrganization_nullGeographicTaxonomies() {
         // given
         OnboardingData onboardingData = mockInstance(new OnboardingData());
         Billing billing = mockInstance(new Billing());
         InstitutionUpdate institutionUpdate = mockInstance(new InstitutionUpdate());
-        institutionUpdate.setGeographicTaxonomies(List.of());
+        institutionUpdate.setGeographicTaxonomies(null);
         onboardingData.setBilling(billing);
         onboardingData.setUsers(List.of(mockInstance(new User())));
         onboardingData.setInstitutionUpdate(institutionUpdate);
@@ -125,8 +125,7 @@ class PartyConnectorImplTest {
                 .onboardingOrganization(onboardingRequestCaptor.capture());
         OnboardingInstitutionRequest request = onboardingRequestCaptor.getValue();
         assertEquals(onboardingData.getInstitutionExternalId(), request.getInstitutionExternalId());
-        assertNotNull(request.getInstitutionUpdate().getGeographicTaxonomyCodes());
-        assertTrue(request.getInstitutionUpdate().getGeographicTaxonomyCodes().isEmpty());
+        assertNull(request.getInstitutionUpdate().getGeographicTaxonomyCodes());
         verifyNoMoreInteractions(restClientMock);
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingDto.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingDto.java
@@ -37,7 +37,6 @@ public class OnboardingDto {
     private PspDataDto pspData;
 
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.geographicTaxonomies}", required = true)
-    @NotNull
     @Valid
     private List<GeographicTaxonomyDto> geographicTaxonomies;
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/OnboardingMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/OnboardingMapper.java
@@ -10,6 +10,7 @@ import it.pagopa.selfcare.onboarding.web.model.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -45,9 +46,11 @@ public class OnboardingMapper {
             resource.setPaymentServiceProvider(mapPaymentServiceProvider(dto.getPspData()));
             resource.setDataProtectionOfficer(mapDataProtectionOfficer(dto.getPspData()));
 
-            resource.setGeographicTaxonomies(dto.getGeographicTaxonomies().stream()
-                    .map(GeographicTaxonomyMapper::fromDto)
-                    .collect(Collectors.toList()));
+            if(Objects.nonNull(dto.getGeographicTaxonomies())) {
+                resource.setGeographicTaxonomies(dto.getGeographicTaxonomies().stream()
+                        .map(GeographicTaxonomyMapper::fromDto)
+                        .collect(Collectors.toList()));
+            }
 
             if (dto.getCompanyInformations() != null) {
                 resource.setRea(dto.getCompanyInformations().getRea());

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionControllerTest.java
@@ -80,6 +80,26 @@ class InstitutionControllerTest {
 
 
     @Test
+    void shouldOnboardingWithoutGeotax(@Value("classpath:stubs/onboardingDtoWithoutGeo.json") Resource onboardingDto) throws Exception {
+        // given
+        String institutionId = "institutionId";
+        String productId = "productId";
+        // when
+        mvc.perform(MockMvcRequestBuilders
+                        .post(BASE_URL + "/{institutionId}/products/{productId}/onboarding", institutionId, productId)
+                        .content(onboardingDto.getInputStream().readAllBytes())
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().isCreated())
+                .andExpect(content().string(emptyString()));
+        // then
+        verify(institutionServiceMock, times(1))
+                .onboarding(any(OnboardingData.class));
+        verifyNoMoreInteractions(institutionServiceMock);
+    }
+
+
+    @Test
     void onboardingSubunit(@Value("classpath:stubs/onboardingSubunitDto.json") Resource onboardingSubunitDto) throws Exception {
         // given
 

--- a/web/src/test/resources/stubs/onboardingDtoWithoutGeo.json
+++ b/web/src/test/resources/stubs/onboardingDtoWithoutGeo.json
@@ -20,11 +20,5 @@
       "surname": "string",
       "taxCode": "string"
     }
-  ],
-  "geographicTaxonomies": [
-    {
-      "code": "string",
-      "desc": "string"
-    }
   ]
 }

--- a/web/src/test/resources/stubs/onboardingDtoWithoutGeo.json
+++ b/web/src/test/resources/stubs/onboardingDtoWithoutGeo.json
@@ -1,0 +1,30 @@
+{
+  "billingData": {
+    "businessName": "string",
+    "digitalAddress": "string",
+    "publicServices": false,
+    "recipientCode": "string",
+    "registeredOffice": "string",
+    "taxCode": "string",
+    "vatNumber": "string",
+    "zipCode": "string"
+  },
+  "institutionType": "GSP",
+  "origin": "string",
+  "pricingPlan": "string",
+  "users": [
+    {
+      "email": "email@example.com",
+      "name": "string",
+      "role": "DELEGATE",
+      "surname": "string",
+      "taxCode": "string"
+    }
+  ],
+  "geographicTaxonomies": [
+    {
+      "code": "string",
+      "desc": "string"
+    }
+  ]
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Remove @NotNull on geoTaxonomies when onboarding

#### Motivation and Context

[Hotfix/SELC-2524]
GeoTaxonomies is optional when onboarding, pdv service can be unreachable

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

Try onboarding with GeoTaxonomies null 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.