### PR TITLE
Removed validation constraints on resources

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1514,9 +1514,7 @@
         "properties" : {
           "supportEmail" : {
             "type" : "string",
-            "description" : "Institution's support email contact",
-            "format" : "email",
-            "example" : "email@example.com"
+            "description" : "Institution's support email contact"
           },
           "supportPhone" : {
             "type" : "string",
@@ -1571,7 +1569,6 @@
       },
       "BusinessResourceIC" : {
         "title" : "BusinessResourceIC",
-        "required" : [ "businessName", "businessTaxId" ],
         "type" : "object",
         "properties" : {
           "businessName" : {
@@ -1660,7 +1657,6 @@
       },
       "GeographicTaxonomyResource" : {
         "title" : "GeographicTaxonomyResource",
-        "required" : [ "code", "desc" ],
         "type" : "object",
         "properties" : {
           "code" : {
@@ -1701,7 +1697,6 @@
       },
       "InstitutionLegalAddressResource" : {
         "title" : "InstitutionLegalAddressResource",
-        "required" : [ "address", "zipCode" ],
         "type" : "object",
         "properties" : {
           "address" : {
@@ -1716,7 +1711,6 @@
       },
       "InstitutionOnboardingInfoResource" : {
         "title" : "InstitutionOnboardingInfoResource",
-        "required" : [ "geographicTaxonomies" ],
         "type" : "object",
         "properties" : {
           "geographicTaxonomies" : {
@@ -1734,7 +1728,6 @@
       },
       "InstitutionResource" : {
         "title" : "InstitutionResource",
-        "required" : [ "address", "description", "digitalAddress", "externalId", "id", "institutionType", "origin", "originId", "taxCode", "userRole", "zipCode" ],
         "type" : "object",
         "properties" : {
           "address" : {
@@ -1788,7 +1781,6 @@
       },
       "InstitutionResourceIC" : {
         "title" : "InstitutionResourceIC",
-        "required" : [ "businesses", "legalTaxId", "requestDateTime" ],
         "type" : "object",
         "properties" : {
           "businesses" : {
@@ -1825,7 +1817,6 @@
       },
       "MatchInfoResultResource" : {
         "title" : "MatchInfoResultResource",
-        "required" : [ "verificationResult" ],
         "type" : "object",
         "properties" : {
           "verificationResult" : {
@@ -2060,7 +2051,6 @@
       },
       "ProductResource" : {
         "title" : "ProductResource",
-        "required" : [ "id", "status", "title" ],
         "type" : "object",
         "properties" : {
           "id" : {

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/AssistanceContactsResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/AssistanceContactsResource.java
@@ -3,13 +3,10 @@ package it.pagopa.selfcare.onboarding.web.model;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
-import javax.validation.constraints.Email;
-
 @Data
 public class AssistanceContactsResource {
 
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.assistance.supportEmail}")
-    @Email
     private String supportEmail;
 
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.assistance.supportPhone}")

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/BusinessResourceIC.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/BusinessResourceIC.java
@@ -1,22 +1,15 @@
 package it.pagopa.selfcare.onboarding.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
-
-import javax.validation.constraints.NotBlank;
 
 @Data
 public class BusinessResourceIC {
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.businessIc.model.businessName}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.businessIc.model.businessName}")
     private String businessName;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.businessIc.model.businessTaxId}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.businessIc.model.businessTaxId}")
     private String businessTaxId;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/CertifiedFieldResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/CertifiedFieldResource.java
@@ -4,18 +4,14 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
-
 @Data
 @NoArgsConstructor
 public class CertifiedFieldResource<T> {
 
-    @ApiModelProperty(value = "${swagger.model.certifiedField.certified}", required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.model.certifiedField.certified}")
     private boolean certified;
 
-    @ApiModelProperty(value = "${swagger.model.certifiedField.value}", required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.model.certifiedField.value}")
     private T value;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/GeographicTaxonomyListResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/GeographicTaxonomyListResource.java
@@ -1,16 +1,12 @@
 package it.pagopa.selfcare.onboarding.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
-import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
 public class GeographicTaxonomyListResource {
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.geographicTaxonomy}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.geographicTaxonomy}")
     private List<GeographicTaxonomyResource> geographicTaxonomies;
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/GeographicTaxonomyResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/GeographicTaxonomyResource.java
@@ -1,21 +1,14 @@
 package it.pagopa.selfcare.onboarding.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
-
-import javax.validation.constraints.NotBlank;
 
 @Data
 public class GeographicTaxonomyResource {
 
-    @ApiModelProperty(value = "${swagger.onboarding.geographicTaxonomy.model.code}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.geographicTaxonomy.model.code}")
     private String code;
 
-    @ApiModelProperty(value = "${swagger.onboarding.geographicTaxonomy.model.desc}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.geographicTaxonomy.model.desc}")
     private String desc;
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/InstitutionLegalAddressResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/InstitutionLegalAddressResource.java
@@ -1,18 +1,15 @@
 package it.pagopa.selfcare.onboarding.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 @Data
 public class InstitutionLegalAddressResource {
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.address}", required = true)
-    @JsonProperty(required = true)
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.address}")
     private String address;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.zipCode}", required = true)
-    @JsonProperty(required = true)
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.zipCode}")
     private String zipCode;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/InstitutionOnboardingInfoResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/InstitutionOnboardingInfoResource.java
@@ -1,22 +1,17 @@
 package it.pagopa.selfcare.onboarding.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
-import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
 public class InstitutionOnboardingInfoResource {
 
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.institutionData}")
-    @NotNull
     private InstitutionData institution;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.geographicTaxonomy}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.geographicTaxonomy}")
     private List<GeographicTaxonomyResource> geographicTaxonomies;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/InstitutionResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/InstitutionResource.java
@@ -1,64 +1,46 @@
 package it.pagopa.selfcare.onboarding.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.commons.base.security.SelfCareAuthority;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.InstitutionType;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Data
 public class InstitutionResource {
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.id}", required = true)
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.id}")
     private UUID id;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.name}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.name}")
     private String description;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.externalId}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.externalId}")
     private String externalId;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.originId}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.originId}")
     private String originId;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.institutionType}", required = true)
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.institutionType}")
     private InstitutionType institutionType;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.digitalAddress}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.digitalAddress}")
     private String digitalAddress;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.address}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.address}")
     private String address;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.zipCode}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.zipCode}")
     private String zipCode;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCode}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCode}")
     private String taxCode;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.origin}", required = true)
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.origin}")
     private String origin;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.userRole}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.userRole}")
     private SelfCareAuthority userRole;
+
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/InstitutionResourceIC.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/InstitutionResourceIC.java
@@ -1,30 +1,20 @@
 package it.pagopa.selfcare.onboarding.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Data
 public class InstitutionResourceIC {
 
-
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.legalTaxId}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.legalTaxId}")
     private String legalTaxId;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.requestDateTime}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.requestDateTime}")
     private String requestDateTime;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.businesses}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.businesses}")
     private List<BusinessResourceIC> businesses;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/MatchInfoResultResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/MatchInfoResultResource.java
@@ -1,18 +1,12 @@
 package it.pagopa.selfcare.onboarding.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
-
-import javax.validation.constraints.NotBlank;
 
 @Data
 public class MatchInfoResultResource {
 
-
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.matchResult}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.matchResult}")
     private boolean verificationResult;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/ProductResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/ProductResource.java
@@ -1,31 +1,22 @@
 package it.pagopa.selfcare.onboarding.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.onboarding.connector.model.product.ProductStatus;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-
 @Data
 public class ProductResource {
 
-    @ApiModelProperty(value = "${swagger.onboarding.product.model.id}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.product.model.id}")
     private String id;
 
-    @ApiModelProperty(value = "${swagger.onboarding.product.model.title}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.product.model.title}")
     private String title;
 
-    @ApiModelProperty(value = "${swagger.onboarding.product.model.parentId}", required = false)
+    @ApiModelProperty(value = "${swagger.onboarding.product.model.parentId}")
     private String parentId;
 
-    @ApiModelProperty(value = "${swagger.onboarding.product.model.status}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.onboarding.product.model.status}")
     private ProductStatus status;
+
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/UserResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/UserResource.java
@@ -1,20 +1,15 @@
 package it.pagopa.selfcare.onboarding.web.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import lombok.Data;
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 @Data
 public class UserResource {
 
-    @ApiModelProperty(value = "${swagger.onboarding.user.model.id}", required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.onboarding.user.model.id}")
     private UUID id;
 
     @ApiModelProperty(value = "${swagger.onboarding.user.model.name}")
@@ -24,28 +19,19 @@ public class UserResource {
     private String surname;
 
     @ApiModelProperty(value = "${swagger.onboarding.user.model.institutionalEmail}")
-    @Email
     private String email;
 
-    @ApiModelProperty(value = "${swagger.onboarding.user.model.fiscalCode}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.user.model.fiscalCode}")
     private String taxCode;
 
-    @ApiModelProperty(value = "${swagger.onboarding.user.model.role}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.onboarding.user.model.role}")
     private PartyRole role;
 
 
-    @ApiModelProperty(value = "${swagger.onboarding.user.model.status}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.user.model.status}")
     private String status;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.id}", required = true)
-    @JsonProperty(required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.id}")
     private UUID institutionId;
 
 }


### PR DESCRIPTION

#### List of Changes

Removed validation constraints on resources.

#### Motivation and Context

It's not necessary to have validation on response objects. This validation is only available for incoming requests and dtos.

#### How Has This Been Tested?

I have started the ms-product-microservice and onboarding-microservice in local aiming dev db and then I have added a new product into mongo collection with missing fields. No error was returned in response.
