### PR TITLE
Refactor: retrieve institutions from infocamere

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -116,6 +116,15 @@
         "summary" : "getInstitutionsByUser",
         "description" : "Get Legal Representative's PN PG institution List",
         "operationId" : "getInstitutionsByUserUsingPOST",
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -148,6 +157,79 @@
           },
           "401" : {
             "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "deprecated" : true,
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/institutions/from-infocamere/" : {
+      "get" : {
+        "tags" : [ "institutions" ],
+        "summary" : "getInstitutionsFromInfocamere",
+        "description" : "Get Legal Representative's PN PG institution List",
+        "operationId" : "getInstitutionsFromInfocamereUsingGET",
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InstitutionResourceIC"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
@@ -904,68 +986,6 @@
         } ]
       }
     },
-    "/pnPGInstitutions" : {
-      "post" : {
-        "tags" : [ "pnPGInstitutions" ],
-        "summary" : "getInstitutionsByUser",
-        "description" : "Get Legal Representative's PN PG institution List",
-        "operationId" : "getInstitutionsByUserUsingPOST_1",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/PnPGUserDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/InstitutionResourceIC"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Internal Server Error",
-            "content" : {
-              "application/problem+json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/Problem"
-                }
-              }
-            }
-          }
-        },
-        "security" : [ {
-          "bearerAuth" : [ "global" ]
-        } ]
-      }
-    },
     "/pnPGInstitutions/{externalInstitutionId}/legal-address" : {
       "get" : {
         "tags" : [ "pnPGInstitutions" ],
@@ -1034,6 +1054,7 @@
             }
           }
         },
+        "deprecated" : true,
         "security" : [ {
           "bearerAuth" : [ "global" ]
         } ]
@@ -1106,6 +1127,7 @@
             }
           }
         },
+        "deprecated" : true,
         "security" : [ {
           "bearerAuth" : [ "global" ]
         } ]
@@ -1200,6 +1222,7 @@
             }
           }
         },
+        "deprecated" : true,
         "security" : [ {
           "bearerAuth" : [ "global" ]
         } ]

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/exceptions/InternalGatewayErrorException.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/exceptions/InternalGatewayErrorException.java
@@ -1,0 +1,10 @@
+package it.pagopa.selfcare.onboarding.connector.exceptions;
+
+public class InternalGatewayErrorException extends RuntimeException {
+    public InternalGatewayErrorException() {
+    }
+
+    public InternalGatewayErrorException(String message) {
+        super(message);
+    }
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/decoder/FeignErrorDecoder.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/decoder/FeignErrorDecoder.java
@@ -2,16 +2,18 @@ package it.pagopa.selfcare.onboarding.connector.rest.decoder;
 
 import feign.Response;
 import feign.codec.ErrorDecoder;
+import it.pagopa.selfcare.onboarding.connector.exceptions.InternalGatewayErrorException;
 import it.pagopa.selfcare.onboarding.connector.exceptions.ResourceNotFoundException;
 
 public class FeignErrorDecoder extends ErrorDecoder.Default {
 
     @Override
     public Exception decode(String methodKey, Response response) {
-        if (response.status() == 404) {
-            throw new ResourceNotFoundException();
-        } else {
-            return super.decode(methodKey, response);
-        }
+        if (response.status() == 404)
+                throw new ResourceNotFoundException();
+        if (response.status() >= 500 && response.status() < 599)
+                throw new InternalGatewayErrorException();
+
+        return super.decode(methodKey, response);
     }
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/rest/decoder/FeignErrorDecoderTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/rest/decoder/FeignErrorDecoderTest.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.onboarding.connector.rest.decoder;
 
 import feign.Request;
 import feign.Response;
+import it.pagopa.selfcare.onboarding.connector.exceptions.InternalGatewayErrorException;
 import it.pagopa.selfcare.onboarding.connector.exceptions.ResourceNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -35,6 +36,21 @@ class FeignErrorDecoderTest {
         Executable executable = () -> feignDecoder.decode("", response);
         //then
         assertThrows(ResourceNotFoundException.class, executable);
+    }
+
+    @Test
+    void testDecodeToServerError() throws Throwable {
+        //given
+        Response response = Response.builder()
+                .status(500)
+                .reason("ResourceNotFound")
+                .request(Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null, UTF_8))
+                .headers(headers)
+                .build();
+        //when
+        Executable executable = () -> feignDecoder.decode("", response);
+        //then
+        assertThrows(InternalGatewayErrorException.class, executable);
     }
 
     @Test

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
@@ -36,6 +36,6 @@ public interface InstitutionService {
 
     InstitutionLegalAddressData getInstitutionLegalAddress(String externalInstitutionId);
 
-    InstitutionInfoIC getInstitutionsByUser(User user);
+    InstitutionInfoIC getInstitutionsByUser(String taxCode);
 
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -438,10 +438,10 @@ class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
-    public InstitutionInfoIC getInstitutionsByUser(User user) {
+    public InstitutionInfoIC getInstitutionsByUser(String taxCode) {
         log.trace("getInstitutionsByUserId start");
-        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitutionsByUserId user = {}", user);
-        InstitutionInfoIC result = partyRegistryProxyConnector.getInstitutionsByUserFiscalCode(user.getTaxCode());
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitutionsByUserId user = {}", taxCode);
+        InstitutionInfoIC result = partyRegistryProxyConnector.getInstitutionsByUserFiscalCode(taxCode);
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitutionsByUserId result = {}", result);
         log.trace("getInstitutionsByUserId end");
         return result;

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -438,10 +438,10 @@ class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
-    public InstitutionInfoIC getInstitutionsByUser(String taxCode) {
+    public InstitutionInfoIC getInstitutionsByUser(String fiscalCode) {
         log.trace("getInstitutionsByUserId start");
-        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitutionsByUserId user = {}", taxCode);
-        InstitutionInfoIC result = partyRegistryProxyConnector.getInstitutionsByUserFiscalCode(taxCode);
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitutionsByUserId user = {}", fiscalCode);
+        InstitutionInfoIC result = partyRegistryProxyConnector.getInstitutionsByUserFiscalCode(fiscalCode);
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitutionsByUserId result = {}", result);
         log.trace("getInstitutionsByUserId end");
         return result;

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -1749,7 +1749,7 @@ class InstitutionServiceImplTest {
         when(partyRegistryProxyConnectorMock.getInstitutionsByUserFiscalCode(anyString()))
                 .thenReturn(institutionInfoICmock);
         //when
-        InstitutionInfoIC result = institutionService.getInstitutionsByUser(user);
+        InstitutionInfoIC result = institutionService.getInstitutionsByUser(user.getTaxCode());
         //then
         assertNotNull(result);
         assertEquals(institutionInfoICmock.getBusinesses().get(0).getBusinessName(), result.getBusinesses().get(0).getBusinessName());

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
@@ -8,7 +8,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
+import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.commons.web.model.Problem;
+import it.pagopa.selfcare.commons.web.security.JwtAuthenticationToken;
 import it.pagopa.selfcare.onboarding.connector.model.InstitutionLegalAddressData;
 import it.pagopa.selfcare.onboarding.connector.model.InstitutionOnboardingData;
 import it.pagopa.selfcare.onboarding.connector.model.institutions.MatchInfoResult;
@@ -16,11 +18,7 @@ import it.pagopa.selfcare.onboarding.connector.model.institutions.infocamere.Ins
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.InstitutionType;
 import it.pagopa.selfcare.onboarding.core.InstitutionService;
 import it.pagopa.selfcare.onboarding.web.model.*;
-import it.pagopa.selfcare.onboarding.web.model.mapper.GeographicTaxonomyMapper;
-import it.pagopa.selfcare.onboarding.web.model.mapper.InstitutionMapper;
-import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingMapper;
-import it.pagopa.selfcare.onboarding.web.model.mapper.UserMapper;
-import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapper;
+import it.pagopa.selfcare.onboarding.web.model.mapper.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -29,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.ValidationException;
+import java.security.Principal;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -225,18 +224,39 @@ public class InstitutionController {
         institutionService.verifyOnboarding(taxCode, subunitCode, productId);
         log.trace("verifyOnboarding end");
     }
+
+    @Deprecated
     @PostMapping(value = "")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.getInstitutionsByUser}")
     public InstitutionResourceIC getInstitutionsByUser(@RequestBody
-                                                         @Valid
-                                                         UserDto userDto) {
+                                                           @Valid
+                                                           UserDto userDto, Principal principal) {
         log.trace("getInstitutionsByUser start");
-        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitutionsByUser userDto = {}", userDto);
-        InstitutionInfoIC institutionInfoIC = institutionService.getInstitutionsByUser(UserMapper.toUser(userDto));
+
+        JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) principal;
+        SelfCareUser selfCareUser = (SelfCareUser) jwtAuthenticationToken.getPrincipal();
+
+        InstitutionInfoIC institutionInfoIC = institutionService.getInstitutionsByUser(selfCareUser.getFiscalCode());
         InstitutionResourceIC institutionResourceIC = InstitutionMapper.toResource(institutionInfoIC);
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitutionsByUser result = {}", institutionResourceIC);
         log.trace("getInstitutionsByUser end");
+        return institutionResourceIC;
+    }
+
+    @GetMapping(value = "/from-infocamere/")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.getInstitutionsByUser}")
+    public InstitutionResourceIC getInstitutionsFromInfocamere(Principal principal) {
+        log.trace("getInstitutionsFromInfocamere start");
+
+        JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) principal;
+        SelfCareUser selfCareUser = (SelfCareUser) jwtAuthenticationToken.getPrincipal();
+
+        InstitutionInfoIC institutionInfoIC = institutionService.getInstitutionsByUser(selfCareUser.getFiscalCode());
+        InstitutionResourceIC institutionResourceIC = InstitutionMapper.toResource(institutionInfoIC);
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitutionsFromInfocamere result = {}", institutionResourceIC);
+        log.trace("getInstitutionsFromInfocamere end");
         return institutionResourceIC;
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/PnPGInstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/PnPGInstitutionController.java
@@ -11,9 +11,11 @@ import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.commons.web.model.Problem;
 import it.pagopa.selfcare.onboarding.connector.model.InstitutionLegalAddressData;
 import it.pagopa.selfcare.onboarding.connector.model.institutions.MatchInfoResult;
-import it.pagopa.selfcare.onboarding.connector.model.institutions.infocamere.InstitutionInfoIC;
 import it.pagopa.selfcare.onboarding.core.PnPGInstitutionService;
-import it.pagopa.selfcare.onboarding.web.model.*;
+import it.pagopa.selfcare.onboarding.web.model.InstitutionLegalAddressResource;
+import it.pagopa.selfcare.onboarding.web.model.MatchInfoResultResource;
+import it.pagopa.selfcare.onboarding.web.model.PnPGOnboardingDto;
+import it.pagopa.selfcare.onboarding.web.model.PnPGUserDto;
 import it.pagopa.selfcare.onboarding.web.model.mapper.PnPGInstitutionMapper;
 import it.pagopa.selfcare.onboarding.web.model.mapper.PnPGOnboardingMapper;
 import it.pagopa.selfcare.onboarding.web.model.mapper.PnPGUserMapper;
@@ -28,6 +30,7 @@ import javax.validation.Valid;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
 
 @Slf4j
+@Deprecated
 @RestController
 @RequestMapping(value = "/pnPGInstitutions", produces = MediaType.APPLICATION_JSON_VALUE)
 @Api(tags = "pnPGInstitutions")
@@ -39,21 +42,6 @@ public class PnPGInstitutionController {
     @Autowired
     public PnPGInstitutionController(PnPGInstitutionService pnPGInstitutionService) {
         this.pnPGInstitutionService = pnPGInstitutionService;
-    }
-
-    @PostMapping(value = "")
-    @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "", notes = "${swagger.onboarding.pnPGInstitutions.api.getInstitutionsByUser}")
-    public InstitutionResourceIC getInstitutionsByUser(@RequestBody
-                                                         @Valid
-                                                         PnPGUserDto userDto) {
-        log.trace("getInstitutionsByUserId start");
-        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitutionsByUserId userDto = {}", userDto);
-        InstitutionInfoIC institutionPnPGInfo = pnPGInstitutionService.getInstitutionsByUser(PnPGUserMapper.toUser(userDto));
-        InstitutionResourceIC institutionPnPGResources = PnPGInstitutionMapper.toResource(institutionPnPGInfo);
-        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitutionsByUserId result = {}", institutionPnPGResources);
-        log.trace("getInstitutionsByUserId end");
-        return institutionPnPGResources;
     }
 
     @ApiResponses(value = {

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/handler/OnboardingExceptionHandler.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/handler/OnboardingExceptionHandler.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.onboarding.web.handler;
 
 import it.pagopa.selfcare.commons.web.model.Problem;
 import it.pagopa.selfcare.commons.web.model.mapper.ProblemMapper;
+import it.pagopa.selfcare.onboarding.connector.exceptions.InternalGatewayErrorException;
 import it.pagopa.selfcare.onboarding.connector.exceptions.ManagerNotFoundException;
 import it.pagopa.selfcare.onboarding.connector.exceptions.ResourceNotFoundException;
 import it.pagopa.selfcare.onboarding.core.exception.InvalidUserFieldsException;
@@ -58,6 +59,12 @@ public class OnboardingExceptionHandler {
     ResponseEntity<Problem> handleOnboardingNotAllowedException(OnboardingNotAllowedException e) {
         log.warn(e.toString());
         return ProblemMapper.toResponseEntity(new Problem(FORBIDDEN, e.getMessage()));
+    }
+
+    @ExceptionHandler({InternalGatewayErrorException.class})
+    ResponseEntity<Problem> handleInternalGatewayErrorException(InternalGatewayErrorException e) {
+        log.warn(e.toString());
+        return ProblemMapper.toResponseEntity(new Problem(BAD_GATEWAY, e.getMessage()));
     }
 
 }

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/PnPGInstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/PnPGInstitutionControllerTest.java
@@ -4,14 +4,11 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.onboarding.connector.model.InstitutionLegalAddressData;
 import it.pagopa.selfcare.onboarding.connector.model.institutions.MatchInfoResult;
-import it.pagopa.selfcare.onboarding.connector.model.institutions.infocamere.BusinessInfoIC;
-import it.pagopa.selfcare.onboarding.connector.model.institutions.infocamere.InstitutionInfoIC;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.PnPGOnboardingData;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.User;
 import it.pagopa.selfcare.onboarding.core.PnPGInstitutionService;
 import it.pagopa.selfcare.onboarding.web.config.WebTestConfig;
 import it.pagopa.selfcare.onboarding.web.model.InstitutionLegalAddressResource;
-import it.pagopa.selfcare.onboarding.web.model.InstitutionResourceIC;
 import it.pagopa.selfcare.onboarding.web.model.MatchInfoResultResource;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -26,10 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.util.List;
-
 import static it.pagopa.selfcare.commons.utils.TestUtils.mockInstance;
-import static java.util.UUID.randomUUID;
 import static org.hamcrest.Matchers.emptyString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -52,41 +46,6 @@ class PnPGInstitutionControllerTest {
 
     @MockBean
     private PnPGInstitutionService pnPGInstitutionServiceMock;
-
-
-    @Test
-    void getInstitutionsByUserId(@Value("classpath:stubs/userDto.json") Resource userDto) throws Exception {
-        //given
-        String userId = randomUUID().toString();
-        List<BusinessInfoIC> businessPnPGList = List.of(mockInstance(new BusinessInfoIC()));
-        InstitutionInfoIC institutionPnPGInfo = mockInstance(new InstitutionInfoIC(), "setBusinesses");
-        institutionPnPGInfo.setBusinesses(businessPnPGList);
-        User user = mockInstance(new User(), "setEmail", "setId", "setProductRole");
-        user.setEmail("n.surname@email.com");
-        when(pnPGInstitutionServiceMock.getInstitutionsByUser(Mockito.any()))
-                .thenReturn(institutionPnPGInfo);
-        //when
-        MvcResult result = mvc.perform(MockMvcRequestBuilders
-                        .post(BASE_URL + "")
-                        .content(userDto.getInputStream().readAllBytes())
-                        .contentType(APPLICATION_JSON_VALUE)
-                        .accept(APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andReturn();
-        // then
-        InstitutionResourceIC response = objectMapper.readValue(
-                result.getResponse().getContentAsString(),
-                new TypeReference<>() {
-                });
-        assertNotNull(response);
-        assertEquals(institutionPnPGInfo.getBusinesses().get(0).getBusinessName(), response.getBusinesses().get(0).getBusinessName());
-        assertEquals(institutionPnPGInfo.getBusinesses().get(0).getBusinessTaxId(), response.getBusinesses().get(0).getBusinessTaxId());
-        assertEquals(institutionPnPGInfo.getLegalTaxId(), response.getLegalTaxId());
-        assertEquals(institutionPnPGInfo.getRequestDateTime(), response.getRequestDateTime());
-        verify(pnPGInstitutionServiceMock, times(1))
-                .getInstitutionsByUser(user);
-        verifyNoMoreInteractions(pnPGInstitutionServiceMock);
-    }
 
     @Test
     void onboarding(@Value("classpath:stubs/onboardingDto.json") Resource onboardingDto) throws Exception {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Retrieve fiscal code from jwt token to invoke infocamere @POST /instituions. No needed to receive a body so this endpoint is deprecated Moving to GET /institutions/from-infocamere/


#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Get institutions from infocamere must be called only from user logged. Fiscalcode will be retrieved from jwt token.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Try call POST /onboarding/v1/instituions without body
Try call GET  /onboarding/v1/institutions/from-infocamere/

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.