### PR TITLE
fix: handle null geotax list when institution does not have geotax

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -403,7 +403,9 @@ class InstitutionServiceImpl implements InstitutionService {
         log.trace("geographicTaxonomyList start");
         log.debug("geographicTaxonomyList externalInstitutionId = {}", externalInstitutionId);
         Assert.hasText(externalInstitutionId, REQUIRED_INSTITUTION_ID_MESSAGE);
-        List<GeographicTaxonomy> result = partyConnector.getInstitutionByExternalId(externalInstitutionId).getGeographicTaxonomies();
+        Institution institution = partyConnector.getInstitutionByExternalId(externalInstitutionId);
+        List<GeographicTaxonomy> result = Optional.ofNullable(institution.getGeographicTaxonomies())
+                .orElse(Collections.emptyList());
         log.debug("geographicTaxonomyList result = {}", result);
         log.trace("geographicTaxonomyList end");
         return result;

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -1688,10 +1688,32 @@ class InstitutionServiceImplTest {
                 .thenReturn(institutionMock);
         // when
         List<GeographicTaxonomy> result = institutionService.getGeographicTaxonomyList(institutionId);
+
+        GeographicTaxonomy expected = institutionMock.getGeographicTaxonomies().get(0);
         // then
         assertNotNull(result);
-        assertEquals(institutionMock.getGeographicTaxonomies().get(0).getCode(), result.get(0).getCode());
-        assertEquals(institutionMock.getGeographicTaxonomies().get(0).getDesc(), result.get(0).getDesc());
+        assertEquals(expected.getCode(), result.get(0).getCode());
+        assertEquals(expected.getDesc(), result.get(0).getDesc());
+        verify(partyConnectorMock, times(1))
+                .getInstitutionByExternalId(institutionId);
+        verifyNoMoreInteractions(partyConnectorMock);
+        verifyNoInteractions(productsConnectorMock, userConnectorMock);
+    }
+
+    @Test
+    void shouldGeographicTaxonomyListEmptyWhenInstitutionGeoListIsNull() {
+        // given
+        String institutionId = "institutionId";
+        Institution institutionMock = mockInstance(new Institution());
+        when(partyConnectorMock.getInstitutionByExternalId(anyString()))
+                .thenReturn(institutionMock);
+        // when
+        List<GeographicTaxonomy> result = institutionService.getGeographicTaxonomyList(institutionId);
+
+        // then
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
         verify(partyConnectorMock, times(1))
                 .getInstitutionByExternalId(institutionId);
         verifyNoMoreInteractions(partyConnectorMock);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

handle null geotax list when institution connector return an institution that does not have geotax.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Throw a NullPointerException when call GET /institutions/{externalInstitutionId}/geographicTaxonomy on an institution that does not have geotax and http response returned 500

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Try to call GET /institutions/{externalInstitutionId}/geographicTaxonomy on an institution that does not have geotax. It must not return http 500 error core.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.