### PR TITLE
SELC-2716 add statusCode 400 in FeignErrorDecoder

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/exceptions/InvalidRequestException.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/exceptions/InvalidRequestException.java
@@ -1,0 +1,5 @@
+package it.pagopa.selfcare.onboarding.connector.exceptions;
+
+public class InvalidRequestException extends RuntimeException {
+    public InvalidRequestException() {}
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/decoder/FeignErrorDecoder.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/decoder/FeignErrorDecoder.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.onboarding.connector.rest.decoder;
 import feign.Response;
 import feign.codec.ErrorDecoder;
 import it.pagopa.selfcare.onboarding.connector.exceptions.InternalGatewayErrorException;
+import it.pagopa.selfcare.onboarding.connector.exceptions.InvalidRequestException;
 import it.pagopa.selfcare.onboarding.connector.exceptions.ResourceNotFoundException;
 
 public class FeignErrorDecoder extends ErrorDecoder.Default {
@@ -11,6 +12,8 @@ public class FeignErrorDecoder extends ErrorDecoder.Default {
     public Exception decode(String methodKey, Response response) {
         if (response.status() == 404)
                 throw new ResourceNotFoundException();
+        if (response.status() == 400)
+                throw new InvalidRequestException();
         if (response.status() >= 500 && response.status() < 599)
                 throw new InternalGatewayErrorException();
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/handler/OnboardingExceptionHandler.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/handler/OnboardingExceptionHandler.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.onboarding.web.handler;
 import it.pagopa.selfcare.commons.web.model.Problem;
 import it.pagopa.selfcare.commons.web.model.mapper.ProblemMapper;
 import it.pagopa.selfcare.onboarding.connector.exceptions.InternalGatewayErrorException;
+import it.pagopa.selfcare.onboarding.connector.exceptions.InvalidRequestException;
 import it.pagopa.selfcare.onboarding.connector.exceptions.ManagerNotFoundException;
 import it.pagopa.selfcare.onboarding.connector.exceptions.ResourceNotFoundException;
 import it.pagopa.selfcare.onboarding.core.exception.InvalidUserFieldsException;
@@ -20,6 +21,12 @@ import static org.springframework.http.HttpStatus.*;
 @Slf4j
 @RestControllerAdvice
 public class OnboardingExceptionHandler {
+
+    @ExceptionHandler({InvalidRequestException.class})
+    ResponseEntity<Problem> handleInvalidRequestException(InvalidRequestException e) {
+        log.warn(e.toString());
+        return ProblemMapper.toResponseEntity(new Problem(BAD_REQUEST, e.getMessage()));
+    }
 
     @ExceptionHandler({ResourceNotFoundException.class})
     ResponseEntity<Problem> handleResourceNotFoundException(ResourceNotFoundException e) {

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/handler/OnboardingExceptionHandlerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/handler/OnboardingExceptionHandlerTest.java
@@ -1,6 +1,8 @@
 package it.pagopa.selfcare.onboarding.web.handler;
 
 import it.pagopa.selfcare.commons.web.model.Problem;
+import it.pagopa.selfcare.onboarding.connector.exceptions.InternalGatewayErrorException;
+import it.pagopa.selfcare.onboarding.connector.exceptions.InvalidRequestException;
 import it.pagopa.selfcare.onboarding.connector.exceptions.ManagerNotFoundException;
 import it.pagopa.selfcare.onboarding.connector.exceptions.ResourceNotFoundException;
 import it.pagopa.selfcare.onboarding.core.exception.InvalidUserFieldsException;
@@ -26,6 +28,40 @@ class OnboardingExceptionHandlerTest {
     public OnboardingExceptionHandlerTest() {
         this.handler = new OnboardingExceptionHandler();
     }
+
+
+    @Test
+    void handleInvalidRequestException() {
+        //given
+        InvalidRequestException exceptionMock = mock(InvalidRequestException.class);
+        when(exceptionMock.getMessage())
+                .thenReturn(DETAIL_MESSAGE);
+        //when
+        ResponseEntity<Problem> responseEntity = handler.handleInvalidRequestException(exceptionMock);
+        //then
+        assertNotNull(responseEntity);
+        assertEquals(BAD_REQUEST, responseEntity.getStatusCode());
+        assertNotNull(responseEntity.getBody());
+        assertEquals(DETAIL_MESSAGE, responseEntity.getBody().getDetail());
+        assertEquals(BAD_REQUEST.value(), responseEntity.getBody().getStatus());
+    }
+
+    @Test
+    void handleInternalGatewayErrorException() {
+        //given
+        InternalGatewayErrorException exceptionMock = mock(InternalGatewayErrorException.class);
+        when(exceptionMock.getMessage())
+                .thenReturn(DETAIL_MESSAGE);
+        //when
+        ResponseEntity<Problem> responseEntity = handler.handleInternalGatewayErrorException(exceptionMock);
+        //then
+        assertNotNull(responseEntity);
+        assertEquals(BAD_GATEWAY, responseEntity.getStatusCode());
+        assertNotNull(responseEntity.getBody());
+        assertEquals(DETAIL_MESSAGE, responseEntity.getBody().getDetail());
+        assertEquals(BAD_GATEWAY.value(), responseEntity.getBody().getStatus());
+    }
+
 
     @Test
     void handleResourceNotFoundException() {


### PR DESCRIPTION
#### List of Changes

- add statusCode 400 in FeignErrorDecoder
- add InvalidRequestException
- add tests for exceptionhandler 

#### Motivation and Context

- Need to catch error 400 in FeignErrorDecoder 

#### How Has This Been Tested?

- try to call /onboarding/v1/institutions/{vatNumber}/match with FLNDVD98L15H501X, 42947449007, this call have to return httpStatus 400
