### PR TITLE
retrieve location data correctly for non IPA institution

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -442,14 +442,18 @@ class InstitutionServiceImpl implements InstitutionService {
         return result;
     }
     private void setInstitutionInfo(Institution institution, InstitutionInfo institutionInfo){
+        InstitutionLocation institutionLocation = new InstitutionLocation();
+        institutionLocation.setCountry(institution.getCountry());
+        institutionLocation.setCity(institution.getCity());
+        institutionLocation.setCounty(institution.getCounty());
+        institutionInfo.setInstitutionLocation(institutionLocation);
         institutionInfo.setSubunitCode(institution.getSubunitCode());
         institutionInfo.setSubunitType(institution.getSubunitType());
         institutionInfo.setOrigin(institution.getOrigin());
     }
 
     private void setLocationInfo(InstitutionInfo institutionInfo){
-        if (institutionInfo.getInstitutionLocation() == null && Origin.IPA.getValue().equals(institutionInfo.getOrigin())){
-            institutionInfo.setInstitutionLocation(new InstitutionLocation());
+        if (institutionInfo.getInstitutionLocation().getCity()==null && Origin.IPA.getValue().equals(institutionInfo.getOrigin())){
             try {
                 GeographicTaxonomies geographicTaxonomies = null;
                 if (institutionInfo.getSubunitType() != null) {

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -2053,7 +2053,7 @@ class InstitutionServiceImplTest {
         institutionInfoMock.setBilling(billingMock);
         when(partyConnectorMock.getInstitutionBillingData(anyString(), anyString()))
                 .thenReturn(institutionInfoMock);
-        Institution institutionMock = mockInstance(new Institution());
+        Institution institutionMock = mockInstance(new Institution(), "setCity");
         institutionMock.setSubunitType(null);
         institutionMock.setOrigin("IPA");
         institutionMock.setGeographicTaxonomies(List.of(new GeographicTaxonomy()));
@@ -2085,7 +2085,7 @@ class InstitutionServiceImplTest {
         institutionInfoMock.setBilling(billingMock);
         when(partyConnectorMock.getInstitutionBillingData(anyString(), anyString()))
                 .thenReturn(institutionInfoMock);
-        Institution institutionMock = mockInstance(new Institution());
+        Institution institutionMock = mockInstance(new Institution(), "setCity");
         institutionMock.setSubunitType("EC");
         institutionMock.setOrigin("IPA");
         institutionMock.setGeographicTaxonomies(List.of(new GeographicTaxonomy()));
@@ -2117,7 +2117,7 @@ class InstitutionServiceImplTest {
         institutionInfoMock.setBilling(billingMock);
         when(partyConnectorMock.getInstitutionBillingData(anyString(), anyString()))
                 .thenReturn(institutionInfoMock);
-        Institution institutionMock = mockInstance(new Institution());
+        Institution institutionMock = mockInstance(new Institution(), "setCity");
         institutionMock.setSubunitType("AOO");
         institutionMock.setOrigin("IPA");
         institutionMock.setGeographicTaxonomies(List.of(new GeographicTaxonomy()));
@@ -2146,7 +2146,7 @@ class InstitutionServiceImplTest {
         institutionInfoMock.setBilling(billingMock);
         when(partyConnectorMock.getInstitutionBillingData(anyString(), anyString()))
                 .thenReturn(institutionInfoMock);
-        Institution institutionMock = mockInstance(new Institution());
+        Institution institutionMock = mockInstance(new Institution(), "setCity");
         institutionMock.setSubunitType("UO");
         institutionMock.setOrigin("IPA");
         institutionMock.setGeographicTaxonomies(List.of(new GeographicTaxonomy()));
@@ -2177,7 +2177,7 @@ class InstitutionServiceImplTest {
         institutionInfoMock.setBilling(billingMock);
         when(partyConnectorMock.getInstitutionBillingData(anyString(), anyString()))
                 .thenReturn(institutionInfoMock);
-        Institution institutionMock = mockInstance(new Institution());
+        Institution institutionMock = mockInstance(new Institution(), "setCity");
         institutionMock.setSubunitType("EC");
         institutionMock.setOrigin("IPA");
         institutionMock.setGeographicTaxonomies(List.of(new GeographicTaxonomy()));


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added mapping to populate institution location for those non ipa institutions that were already persisted on selfcare

#### Motivation and Context

The location informations of non IPA institutions that were already persisted on selfcare weren't retrieved properly, hence when the getInstitutionOnboardingInfo api gets called they weren't returned correctly. Prompting the FE to ask for those informations again from the user

#### How Has This Been Tested?

Tested Locally

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.