### PR TITLE
ops: move /v1 from helm to controller

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -36,7 +36,7 @@
     "description" : "User Controller"
   } ],
   "paths" : {
-    "/institutions" : {
+    "/v1/institutions" : {
       "get" : {
         "tags" : [ "institutions" ],
         "summary" : "getInstitutions",
@@ -112,7 +112,7 @@
         } ]
       }
     },
-    "/institutions/company/onboarding" : {
+    "/v1/institutions/company/onboarding" : {
       "post" : {
         "tags" : [ "institutions" ],
         "summary" : "onboarding",
@@ -197,7 +197,7 @@
         } ]
       }
     },
-    "/institutions/from-infocamere/" : {
+    "/v1/institutions/from-infocamere/" : {
       "get" : {
         "tags" : [ "institutions" ],
         "summary" : "getInstitutionsFromInfocamere",
@@ -269,7 +269,7 @@
         } ]
       }
     },
-    "/institutions/geographicTaxonomies" : {
+    "/v1/institutions/geographicTaxonomies" : {
       "get" : {
         "tags" : [ "institutions" ],
         "summary" : "getGeographicTaxonomiesByTaxCodeAndSubunitCode",
@@ -354,7 +354,7 @@
         } ]
       }
     },
-    "/institutions/onboarding" : {
+    "/v1/institutions/onboarding" : {
       "post" : {
         "tags" : [ "institutions" ],
         "summary" : "onboarding",
@@ -561,7 +561,7 @@
         } ]
       }
     },
-    "/institutions/onboarding/" : {
+    "/v1/institutions/onboarding/" : {
       "get" : {
         "tags" : [ "institutions" ],
         "summary" : "getInstitutionOnboardingInfo",
@@ -652,7 +652,7 @@
         } ]
       }
     },
-    "/institutions/verification/legal-address" : {
+    "/v1/institutions/verification/legal-address" : {
       "post" : {
         "tags" : [ "institutions" ],
         "summary" : "postVerificationLegalAddress",
@@ -734,7 +734,7 @@
         } ]
       }
     },
-    "/institutions/verification/match" : {
+    "/v1/institutions/verification/match" : {
       "post" : {
         "tags" : [ "institutions" ],
         "summary" : "postVerificationMatch",
@@ -816,7 +816,7 @@
         } ]
       }
     },
-    "/institutions/{externalInstitutionId}/geographicTaxonomy" : {
+    "/v1/institutions/{externalInstitutionId}/geographicTaxonomy" : {
       "get" : {
         "tags" : [ "institutions" ],
         "summary" : "getInstitutionGeographicTaxonomy",
@@ -892,7 +892,7 @@
         } ]
       }
     },
-    "/institutions/{externalInstitutionId}/legal-address" : {
+    "/v1/institutions/{externalInstitutionId}/legal-address" : {
       "get" : {
         "tags" : [ "institutions" ],
         "summary" : "getInstitutionLegalAddress",
@@ -966,7 +966,7 @@
         } ]
       }
     },
-    "/institutions/{externalInstitutionId}/match" : {
+    "/v1/institutions/{externalInstitutionId}/match" : {
       "post" : {
         "tags" : [ "institutions" ],
         "summary" : "matchInstitutionAndUser",
@@ -1059,7 +1059,7 @@
         } ]
       }
     },
-    "/institutions/{externalInstitutionId}/products/{productId}" : {
+    "/v1/institutions/{externalInstitutionId}/products/{productId}" : {
       "head" : {
         "tags" : [ "institutions" ],
         "summary" : "verifyOnboarding",
@@ -1144,7 +1144,7 @@
         } ]
       }
     },
-    "/institutions/{externalInstitutionId}/products/{productId}/onboarded-institution-info" : {
+    "/v1/institutions/{externalInstitutionId}/products/{productId}/onboarded-institution-info" : {
       "get" : {
         "tags" : [ "institutions" ],
         "summary" : "getInstitutionOnboardingInfo",
@@ -1227,7 +1227,7 @@
         } ]
       }
     },
-    "/institutions/{externalInstitutionId}/products/{productId}/onboarding" : {
+    "/v1/institutions/{externalInstitutionId}/products/{productId}/onboarding" : {
       "post" : {
         "tags" : [ "institutions" ],
         "summary" : "onboarding",
@@ -1332,7 +1332,7 @@
         } ]
       }
     },
-    "/pnPGInstitutions/{externalInstitutionId}/legal-address" : {
+    "/v1/pnPGInstitutions/{externalInstitutionId}/legal-address" : {
       "get" : {
         "tags" : [ "pnPGInstitutions" ],
         "summary" : "getInstitutionLegalAddress",
@@ -1406,7 +1406,7 @@
         } ]
       }
     },
-    "/pnPGInstitutions/{externalInstitutionId}/match" : {
+    "/v1/pnPGInstitutions/{externalInstitutionId}/match" : {
       "post" : {
         "tags" : [ "pnPGInstitutions" ],
         "summary" : "matchInstitutionAndUser",
@@ -1499,7 +1499,7 @@
         } ]
       }
     },
-    "/pnPGInstitutions/{externalInstitutionId}/products/{productId}/onboarding" : {
+    "/v1/pnPGInstitutions/{externalInstitutionId}/products/{productId}/onboarding" : {
       "post" : {
         "tags" : [ "pnPGInstitutions" ],
         "summary" : "onboardingPG",
@@ -1604,7 +1604,7 @@
         } ]
       }
     },
-    "/product/{id}" : {
+    "/v1/product/{id}" : {
       "get" : {
         "tags" : [ "product" ],
         "summary" : "getProduct",
@@ -1687,7 +1687,7 @@
         } ]
       }
     },
-    "/tokens/{tokenId}/complete" : {
+    "/v1/tokens/{tokenId}/complete" : {
       "post" : {
         "tags" : [ "tokens" ],
         "summary" : "Complete an onboarding request",
@@ -1834,7 +1834,7 @@
         } ]
       }
     },
-    "/tokens/{tokenId}/verify" : {
+    "/v1/tokens/{tokenId}/verify" : {
       "post" : {
         "tags" : [ "tokens" ],
         "summary" : "Verify if the token is already consumed",
@@ -1917,7 +1917,7 @@
         } ]
       }
     },
-    "/users/validate" : {
+    "/v1/users/validate" : {
       "post" : {
         "tags" : [ "user" ],
         "summary" : "validate",

--- a/helm/pnpg/values-dev.yaml
+++ b/helm/pnpg/values-dev.yaml
@@ -11,7 +11,7 @@ ingress:
   hosts:
     - host: "dev01.pnpg.internal.dev.selfcare.pagopa.it"
       paths:
-        - path: /onboarding/v1/(.*)
+        - path: /onboarding/(.*)
           pathType: ImplementationSpecific
 
 autoscaling:

--- a/helm/pnpg/values-prod.yaml
+++ b/helm/pnpg/values-prod.yaml
@@ -13,7 +13,7 @@ ingress:
   hosts:
     - host: "prod01.pnpg.internal.selfcare.pagopa.it"
       paths:
-        - path: /onboarding/v1/(.*)
+        - path: /onboarding/(.*)
           pathType: ImplementationSpecific
 
 autoscaling:

--- a/helm/pnpg/values-uat.yaml
+++ b/helm/pnpg/values-uat.yaml
@@ -12,7 +12,7 @@ ingress:
   hosts:
     - host: "uat01.pnpg.internal.uat.selfcare.pagopa.it"
       paths:
-        - path: /onboarding/v1/(.*)
+        - path: /onboarding/(.*)
           pathType: ImplementationSpecific
 
 autoscaling:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -11,7 +11,7 @@ ingress:
   hosts:
     - host: selc.internal.dev.selfcare.pagopa.it
       paths:
-        - path: /onboarding/v1/(.*)
+        - path: /onboarding/(.*)
           pathType: ImplementationSpecific
 
 resources:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -15,7 +15,7 @@ ingress:
   hosts:
     - host: "selc.internal.selfcare.pagopa.it"
       paths:
-        - path: /onboarding/v1/(.*)
+        - path: /onboarding/(.*)
           pathType: ImplementationSpecific
 
 autoscaling:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -14,7 +14,7 @@ ingress:
   hosts:
     - host: "selc.internal.uat.selfcare.pagopa.it"
       paths:
-        - path: /onboarding/v1/(.*)
+        - path: /onboarding/(.*)
           pathType: ImplementationSpecific
 
 autoscaling:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -51,7 +51,7 @@ ingress:
   hosts:
     - host: ""
       paths:
-        - path: /onboarding/v1/(.*)
+        - path: /onboarding/(.*)
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
@@ -42,7 +42,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.HEAD;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/institutions", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/v1/institutions", produces = MediaType.APPLICATION_JSON_VALUE)
 @Api(tags = "institutions")
 public class InstitutionController {
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/PnPGInstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/PnPGInstitutionController.java
@@ -35,7 +35,7 @@ import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
 @Slf4j
 @Deprecated(forRemoval = true)
 @RestController
-@RequestMapping(value = "/pnPGInstitutions", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/v1/pnPGInstitutions", produces = MediaType.APPLICATION_JSON_VALUE)
 @Api(tags = "pnPGInstitutions")
 public class PnPGInstitutionController {
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/ProductController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/ProductController.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/product", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/v1/product", produces = MediaType.APPLICATION_JSON_VALUE)
 @Api(tags = "product")
 public class ProductController {
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenController.java
@@ -16,7 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/tokens", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/v1/tokens", produces = MediaType.APPLICATION_JSON_VALUE)
 @Api(tags = "tokens")
 public class TokenController {
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/UserController.java
@@ -21,7 +21,7 @@ import javax.validation.Valid;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/users", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/v1/users", produces = MediaType.APPLICATION_JSON_VALUE)
 @Api(tags = "user")
 public class UserController {
 

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionControllerTest.java
@@ -52,7 +52,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = {InstitutionController.class, WebTestConfig.class, OnboardingResourceMapperImpl.class, OnboardingInstitutionInfoMapperImpl.class})
 class InstitutionControllerTest {
 
-    private static final String BASE_URL = "/institutions";
+    private static final String BASE_URL = "/v1/institutions";
 
     @Autowired
     protected MockMvc mvc;

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/PnPGInstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/PnPGInstitutionControllerTest.java
@@ -36,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ContextConfiguration(classes = {PnPGInstitutionController.class, WebTestConfig.class})
 class PnPGInstitutionControllerTest {
 
-    private static final String BASE_URL = "/pnPGInstitutions";
+    private static final String BASE_URL = "/v1/pnPGInstitutions";
 
     @Autowired
     protected MockMvc mvc;

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/ProductControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/ProductControllerTest.java
@@ -28,7 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
         WebTestConfig.class
 })
 class ProductControllerTest {
-    private static final String BASE_URL = "/product";
+    private static final String BASE_URL = "/v1/product";
 
     @Autowired
     protected MockMvc mvc;

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenControllerTest.java
@@ -46,7 +46,7 @@ public class TokenControllerTest {
 
         //when
         mvc.perform(MockMvcRequestBuilders
-                        .post("/tokens/{tokenId}/verify", id)
+                        .post("/v1/tokens/{tokenId}/verify", id)
                         .contentType(APPLICATION_JSON_VALUE)
                         .accept(APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
@@ -64,7 +64,7 @@ public class TokenControllerTest {
 
         MockMultipartFile file = new MockMultipartFile("contract", "".getBytes());
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
-                .multipart("/tokens/{tokenId}/complete",
+                .multipart("/v1/tokens/{tokenId}/complete",
                         "42")
                 .file(file);
         mvc.perform(requestBuilder)
@@ -82,7 +82,7 @@ public class TokenControllerTest {
 
         //when
         mvc.perform(MockMvcRequestBuilders
-                        .delete("/tokens/{tokenId}/complete", id)
+                        .delete("/v1/tokens/{tokenId}/complete", id)
                         .contentType(APPLICATION_JSON_VALUE)
                         .accept(APPLICATION_JSON_VALUE))
                 .andExpect(status().isNoContent());

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/UserControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/UserControllerTest.java
@@ -31,7 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 class UserControllerTest {
 
-    private static final String BASE_URL = "/users";
+    private static final String BASE_URL = "/v1/users";
 
     @Autowired
     protected MockMvc mvc;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* Remove /v1 prefix at helm file
* Added /v1 prefix to web controller

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

/v1 prefix at helm value does not permit to add a new version of the endpoint, for example /v2/onboarding. Moving the prefix to controller enable possibility to create a new version of web controllers.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.