### PR TITLE
[SELC-3452] feat: added V2 for new onboarding request

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1702,6 +1702,16 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "name" : "mode",
+          "in" : "query",
+          "description" : "mode",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ASYNC", "SYNC" ]
+          }
         } ],
         "requestBody" : {
           "content" : {

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -360,17 +360,6 @@
         "summary" : "onboarding",
         "description" : "The service allows the onboarding of Users to a subunit of an Institution",
         "operationId" : "onboardingUsingPOST_1",
-        "parameters" : [ {
-          "name" : "mode",
-          "in" : "query",
-          "description" : "mode",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ASYNC", "SYNC" ]
-          }
-        } ],
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -1332,6 +1321,91 @@
         } ]
       }
     },
+    "/v2/institutions/onboarding" : {
+      "post" : {
+        "tags" : [ "institutions" ],
+        "summary" : "onboarding",
+        "description" : "The service allows the onboarding of Users to a subunit of an Institution",
+        "operationId" : "onboardingUsingPOST_3",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OnboardingProductDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/v1/pnPGInstitutions/{externalInstitutionId}/legal-address" : {
       "get" : {
         "tags" : [ "pnPGInstitutions" ],
@@ -1702,16 +1776,6 @@
           "schema" : {
             "type" : "string"
           }
-        }, {
-          "name" : "mode",
-          "in" : "query",
-          "description" : "mode",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "ASYNC", "SYNC" ]
-          }
         } ],
         "requestBody" : {
           "content" : {
@@ -1870,6 +1934,99 @@
                 }
               }
             }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/v2/tokens/{onboardingId}/complete" : {
+      "post" : {
+        "tags" : [ "tokens" ],
+        "summary" : "Complete an onboarding request",
+        "description" : "Complete an onboarding request",
+        "operationId" : "completeUsingPOST_1",
+        "parameters" : [ {
+          "name" : "onboardingId",
+          "in" : "path",
+          "description" : "Contract's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "required" : [ "contract" ],
+                "type" : "object",
+                "properties" : {
+                  "contract" : {
+                    "type" : "string",
+                    "description" : "contract",
+                    "format" : "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
           },
           "400" : {
             "description" : "Bad Request",

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
@@ -1,0 +1,10 @@
+package it.pagopa.selfcare.onboarding.connector.api;
+
+import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface OnboardingMsConnector {
+    void onboarding(OnboardingData onboardingData);
+
+    void onboardingTokenComplete(String onboardingId, MultipartFile contract);
+}

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/PartyConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/PartyConnector.java
@@ -13,8 +13,6 @@ import java.util.List;
 
 public interface PartyConnector {
 
-    void onboarding(OnboardingData onboardingData);
-
     void onboardingOrganization(OnboardingData onboardingData);
 
     Collection<InstitutionInfo> getOnBoardedInstitutions(String productFilter);

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -129,8 +129,15 @@
           "content" : {
             "multipart/form-data" : {
               "schema" : {
-                "format" : "binary",
-                "type" : "string"
+                "required" : [ "contract" ],
+                "type" : "object",
+                "properties" : {
+                  "contract" : {
+                    "type" : "string",
+                    "description" : "contract",
+                    "format" : "binary"
+                  }
+                }
               }
             }
           }

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -1,13 +1,14 @@
 {
   "openapi" : "3.0.3",
   "info" : {
-    "title" : "onboarding-ms API",
-    "version" : "1.0.0-SNAPSHOT"
+    "title" : "Onboarding API (development)",
+    "version" : "1.0.0"
   },
   "paths" : {
-    "/onboarding" : {
+    "/v1/onboarding" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
+        "summary" : "Perform default onboarding request, it is used for GSP/SA/AS institution type.Users data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding based on institution type.",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -27,13 +28,23 @@
                 }
               }
             }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
-        }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
       }
     },
-    "/onboarding/pa" : {
+    "/v1/onboarding/pa" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
+        "summary" : "Perform onboarding request for PA institution type, it require billing.recipientCode in additition to default requestUsers data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding that consist of create contract and sending mail to institution's digital address.",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -53,13 +64,23 @@
                 }
               }
             }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
-        }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
       }
     },
-    "/onboarding/psp" : {
+    "/v1/onboarding/psp" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
+        "summary" : "Perform onboarding request for PSP institution type.Users data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding that consist of sending mail to Selfcare admin for approve request.",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -79,14 +100,64 @@
                 }
               }
             }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
-        }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/v1/onboarding/{onboardingId}/complete" : {
+      "put" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "Perform complete operation of an onboarding request receiving onboarding id and contract signed by hte institution.It checks the contract's signature and upload the contract on an azure storageAt the end, function triggers async activities related to complete onboarding that consist of create the institution, activate the onboarding and sending data to notification queue.",
+        "parameters" : [ {
+          "name" : "onboardingId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "format" : "binary",
+                "type" : "string"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : { }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
       }
     }
   },
   "components" : {
     "schemas" : {
-      "BillingRequest" : {
+      "BillingPaRequest" : {
         "required" : [ "vatNumber", "recipientCode" ],
         "type" : "object",
         "properties" : {
@@ -96,6 +167,22 @@
           },
           "recipientCode" : {
             "minLength" : 1,
+            "type" : "string"
+          },
+          "publicServices" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "BillingRequest" : {
+        "required" : [ "vatNumber" ],
+        "type" : "object",
+        "properties" : {
+          "vatNumber" : {
+            "minLength" : 1,
+            "type" : "string"
+          },
+          "recipientCode" : {
             "type" : "string"
           },
           "publicServices" : {
@@ -145,7 +232,7 @@
         }
       },
       "InstitutionBaseRequest" : {
-        "required" : [ "institutionType", "taxCode" ],
+        "required" : [ "institutionType", "taxCode", "digitalAddress" ],
         "type" : "object",
         "properties" : {
           "institutionType" : {
@@ -161,10 +248,23 @@
           "subunitType" : {
             "$ref" : "#/components/schemas/InstitutionPaSubunitType"
           },
+          "origin" : {
+            "$ref" : "#/components/schemas/Origin"
+          },
+          "city" : {
+            "type" : "string"
+          },
+          "country" : {
+            "type" : "string"
+          },
+          "county" : {
+            "type" : "string"
+          },
           "description" : {
             "type" : "string"
           },
           "digitalAddress" : {
+            "minLength" : 1,
             "type" : "string"
           },
           "address" : {
@@ -204,7 +304,7 @@
         "type" : "string"
       },
       "InstitutionPspRequest" : {
-        "required" : [ "institutionType", "taxCode", "paymentServiceProvider" ],
+        "required" : [ "institutionType", "taxCode", "digitalAddress", "paymentServiceProvider" ],
         "type" : "object",
         "properties" : {
           "institutionType" : {
@@ -220,10 +320,23 @@
           "subunitType" : {
             "$ref" : "#/components/schemas/InstitutionPaSubunitType"
           },
+          "origin" : {
+            "$ref" : "#/components/schemas/Origin"
+          },
+          "city" : {
+            "type" : "string"
+          },
+          "country" : {
+            "type" : "string"
+          },
+          "county" : {
+            "type" : "string"
+          },
           "description" : {
             "type" : "string"
           },
           "digitalAddress" : {
+            "minLength" : 1,
             "type" : "string"
           },
           "address" : {
@@ -279,6 +392,18 @@
           "subunitType" : {
             "$ref" : "#/components/schemas/InstitutionPaSubunitType"
           },
+          "origin" : {
+            "$ref" : "#/components/schemas/Origin"
+          },
+          "city" : {
+            "type" : "string"
+          },
+          "country" : {
+            "type" : "string"
+          },
+          "county" : {
+            "type" : "string"
+          },
           "description" : {
             "type" : "string"
           },
@@ -321,7 +446,7 @@
         }
       },
       "InstitutionType" : {
-        "enum" : [ "PA", "PG", "GSP", "SA", "PT", "SCP", "PSP" ],
+        "enum" : [ "PA", "PG", "GSP", "SA", "PT", "SCP", "PSP", "AS" ],
         "type" : "string"
       },
       "OffsetDateTime" : {
@@ -330,7 +455,7 @@
         "example" : "2022-03-10T12:15:50-04:00"
       },
       "OnboardingDefaultRequest" : {
-        "required" : [ "productId", "users", "institution" ],
+        "required" : [ "productId", "users", "institution", "billing" ],
         "type" : "object",
         "properties" : {
           "productId" : {
@@ -355,6 +480,9 @@
           },
           "signContract" : {
             "type" : "boolean"
+          },
+          "userRequestUid" : {
+            "type" : "string"
           },
           "institution" : {
             "$ref" : "#/components/schemas/InstitutionBaseRequest"
@@ -408,11 +536,14 @@
           "signContract" : {
             "type" : "boolean"
           },
+          "userRequestUid" : {
+            "type" : "string"
+          },
           "institution" : {
             "$ref" : "#/components/schemas/InstitutionBaseRequest"
           },
           "billing" : {
-            "$ref" : "#/components/schemas/BillingRequest"
+            "$ref" : "#/components/schemas/BillingPaRequest"
           }
         }
       },
@@ -443,6 +574,9 @@
           "signContract" : {
             "type" : "boolean"
           },
+          "userRequestUid" : {
+            "type" : "string"
+          },
           "institution" : {
             "$ref" : "#/components/schemas/InstitutionPspRequest"
           },
@@ -471,8 +605,15 @@
           },
           "billing" : {
             "$ref" : "#/components/schemas/BillingResponse"
+          },
+          "userRequestUid" : {
+            "type" : "string"
           }
         }
+      },
+      "Origin" : {
+        "enum" : [ "MOCK", "IPA", "SELC", "ANAC", "UNKNOWN", "ADE", "INFOCAMERE", "IVASS" ],
+        "type" : "string"
       },
       "PartyRole" : {
         "enum" : [ "MANAGER", "DELEGATE", "SUB_DELEGATE", "OPERATOR" ],

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
@@ -1,0 +1,42 @@
+package it.pagopa.selfcare.onboarding.connector;
+
+import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.connector.api.OnboardingMsConnector;
+import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
+import it.pagopa.selfcare.onboarding.connector.rest.client.MsOnboardingApiClient;
+import it.pagopa.selfcare.onboarding.connector.rest.mapper.OnboardingMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Slf4j
+public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
+
+
+
+    private final MsOnboardingApiClient msOnboardingApiClient;
+
+    private final OnboardingMapper onboardingMapper;
+
+    public OnboardingMsConnectorImpl(MsOnboardingApiClient msOnboardingApiClient, OnboardingMapper onboardingMapper) {
+        this.msOnboardingApiClient = msOnboardingApiClient;
+        this.onboardingMapper = onboardingMapper;
+    }
+
+    @Override
+    public void onboarding(OnboardingData onboardingData) {
+        if (onboardingData.getInstitutionType() == InstitutionType.PA) {
+            msOnboardingApiClient._v1OnboardingPaPost(onboardingMapper.toOnboardingPaRequest(onboardingData));
+        } else if (onboardingData.getInstitutionType() == InstitutionType.PSP) {
+            msOnboardingApiClient._v1OnboardingPspPost(onboardingMapper.toOnboardingPspRequest(onboardingData));
+        } else {
+            msOnboardingApiClient._v1OnboardingPost(onboardingMapper.toOnboardingDefaultRequest(onboardingData));
+        }
+    }
+
+    @Override
+    public void onboardingTokenComplete(String onboardingId, MultipartFile contract) {
+        msOnboardingApiClient._v1OnboardingOnboardingIdCompletePut(onboardingId);
+    }
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
@@ -37,6 +37,6 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
 
     @Override
     public void onboardingTokenComplete(String onboardingId, MultipartFile contract) {
-        msOnboardingApiClient._v1OnboardingOnboardingIdCompletePut(onboardingId);
+        msOnboardingApiClient._v1OnboardingOnboardingIdCompletePut(onboardingId, contract);
     }
 }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImpl.java
@@ -1,7 +1,6 @@
 package it.pagopa.selfcare.onboarding.connector;
 
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.onboarding.connector.api.PartyConnector;
 import it.pagopa.selfcare.onboarding.connector.model.RelationshipInfo;
 import it.pagopa.selfcare.onboarding.connector.model.RelationshipsResponse;
@@ -11,10 +10,8 @@ import it.pagopa.selfcare.onboarding.connector.model.institutions.OnboardingReso
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.*;
 import it.pagopa.selfcare.onboarding.connector.rest.client.MsCoreOnboardingApiClient;
 import it.pagopa.selfcare.onboarding.connector.rest.client.MsCoreTokenApiClient;
-import it.pagopa.selfcare.onboarding.connector.rest.client.MsOnboardingApiClient;
 import it.pagopa.selfcare.onboarding.connector.rest.client.PartyProcessRestClient;
 import it.pagopa.selfcare.onboarding.connector.rest.mapper.InstitutionMapper;
-import it.pagopa.selfcare.onboarding.connector.rest.mapper.OnboardingMapper;
 import it.pagopa.selfcare.onboarding.connector.rest.model.InstitutionUpdate;
 import it.pagopa.selfcare.onboarding.connector.rest.model.*;
 import lombok.extern.slf4j.Slf4j;
@@ -47,10 +44,6 @@ class PartyConnectorImpl implements PartyConnector {
     private final PartyProcessRestClient restClient;
     private final InstitutionMapper institutionMapper;
 
-    private final MsOnboardingApiClient msOnboardingApiClient;
-
-    private final OnboardingMapper onboardingMapper;
-
     private static final BinaryOperator<InstitutionInfo> MERGE_FUNCTION =
             (inst1, inst2) -> inst1.getUserRole().compareTo(inst2.getUserRole()) < 0 ? inst1 : inst2;
     private static final Function<OnboardingResponseData, InstitutionInfo> ONBOARDING_DATA_TO_INSTITUTION_INFO_FUNCTION = onboardingData -> {
@@ -80,25 +73,11 @@ class PartyConnectorImpl implements PartyConnector {
     };
 
     @Autowired
-    public PartyConnectorImpl(MsCoreTokenApiClient msCoreTokenApiClient, MsCoreOnboardingApiClient msCoreOnboardingApiClient, PartyProcessRestClient restClient, InstitutionMapper institutionMapper, MsOnboardingApiClient msOnboardingApiClient, OnboardingMapper onboardingMapper) {
+    public PartyConnectorImpl(MsCoreTokenApiClient msCoreTokenApiClient, MsCoreOnboardingApiClient msCoreOnboardingApiClient, PartyProcessRestClient restClient, InstitutionMapper institutionMapper) {
         this.msCoreTokenApiClient = msCoreTokenApiClient;
         this.msCoreOnboardingApiClient = msCoreOnboardingApiClient;
         this.restClient = restClient;
         this.institutionMapper = institutionMapper;
-        this.msOnboardingApiClient = msOnboardingApiClient;
-        this.onboardingMapper = onboardingMapper;
-    }
-
-
-    @Override
-    public void onboarding(OnboardingData onboardingData) {
-        if (onboardingData.getInstitutionType() == InstitutionType.PA) {
-            msOnboardingApiClient._onboardingPaPost(onboardingMapper.toOnboardingPaRequest(onboardingData));
-        } else if (onboardingData.getInstitutionType() == InstitutionType.PSP) {
-            msOnboardingApiClient._onboardingPspPost(onboardingMapper.toOnboardingPspRequest(onboardingData));
-        } else {
-            msOnboardingApiClient._onboardingPost(onboardingMapper.toOnboardingDefaultRequest(onboardingData));
-        }
     }
 
     @Override

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
@@ -10,17 +10,21 @@ import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingPaReques
 import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingPspRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static it.pagopa.selfcare.commons.utils.TestUtils.mockInstance;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -105,6 +109,21 @@ public class OnboardingMsConnectorImplTest {
         assertEquals(actual.getInstitution().getTaxCode(), institutionUpdate.getTaxCode());
         assertNotNull(actual.getInstitution().getPaymentServiceProvider());
         assertNotNull(actual.getInstitution().getDataProtectionOfficer());
+        verifyNoMoreInteractions(msOnboardingApiClient);
+    }
+
+    @Test
+    void onboardingComplete() throws IOException {
+        // given
+        final String tokenId = "tokenId";
+        final MockMultipartFile mockMultipartFile =
+                new MockMultipartFile("example", new ByteArrayInputStream("example".getBytes(StandardCharsets.UTF_8)));
+        // when
+        final Executable executable = () -> msOnboardingApiClient._v1OnboardingOnboardingIdCompletePut(tokenId, mockMultipartFile);
+        // then
+        assertDoesNotThrow(executable);
+        verify(msOnboardingApiClient, times(1))
+                ._v1OnboardingOnboardingIdCompletePut(tokenId, mockMultipartFile);
         verifyNoMoreInteractions(msOnboardingApiClient);
     }
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
@@ -1,0 +1,110 @@
+package it.pagopa.selfcare.onboarding.connector;
+
+import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.onboarding.connector.model.onboarding.*;
+import it.pagopa.selfcare.onboarding.connector.rest.client.MsOnboardingApiClient;
+import it.pagopa.selfcare.onboarding.connector.rest.mapper.OnboardingMapper;
+import it.pagopa.selfcare.onboarding.connector.rest.mapper.OnboardingMapperImpl;
+import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingDefaultRequest;
+import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingPaRequest;
+import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingPspRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static it.pagopa.selfcare.commons.utils.TestUtils.mockInstance;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class OnboardingMsConnectorImplTest {
+
+    @InjectMocks
+    private OnboardingMsConnectorImpl onboardingMsConnector;
+    @Mock
+    private MsOnboardingApiClient msOnboardingApiClient;
+
+    @Spy
+    private OnboardingMapper onboardingMapper = new OnboardingMapperImpl();
+
+    @Test
+    void onboarding_institutionDefault() {
+        // given
+        OnboardingData onboardingData = new OnboardingData();
+        onboardingData.setTaxCode("taxCode");
+        onboardingData.setInstitutionType(InstitutionType.GSP);
+        Billing billing = mockInstance(new Billing());
+        InstitutionUpdate institutionUpdate = new InstitutionUpdate();
+        institutionUpdate.setTaxCode("taxCode");
+        onboardingData.setBilling(billing);
+        onboardingData.setUsers(List.of(mockInstance(new User())));
+        onboardingData.setInstitutionUpdate(institutionUpdate);
+        // when
+        onboardingMsConnector.onboarding(onboardingData);
+        // then
+
+        ArgumentCaptor<OnboardingDefaultRequest> onboardingRequestCaptor = ArgumentCaptor.forClass(OnboardingDefaultRequest.class);
+        verify(msOnboardingApiClient, times(1))
+                ._v1OnboardingPost(onboardingRequestCaptor.capture());
+        OnboardingDefaultRequest actual = onboardingRequestCaptor.getValue();
+        assertEquals(actual.getInstitution().getTaxCode(), institutionUpdate.getTaxCode());
+        verifyNoMoreInteractions(msOnboardingApiClient);
+    }
+
+    @Test
+    void onboarding_institutionPa() {
+        // given
+        OnboardingData onboardingData = new OnboardingData();
+        onboardingData.setTaxCode("taxCode");
+        onboardingData.setInstitutionType(InstitutionType.PA);
+        Billing billing = mockInstance(new Billing());
+        InstitutionUpdate institutionUpdate = new InstitutionUpdate();
+        institutionUpdate.setTaxCode("taxCode");
+        onboardingData.setBilling(billing);
+        onboardingData.setUsers(List.of(mockInstance(new User())));
+        onboardingData.setInstitutionUpdate(institutionUpdate);
+        // when
+        onboardingMsConnector.onboarding(onboardingData);
+        // then
+
+        ArgumentCaptor<OnboardingPaRequest> onboardingRequestCaptor = ArgumentCaptor.forClass(OnboardingPaRequest.class);
+        verify(msOnboardingApiClient, times(1))
+                ._v1OnboardingPaPost(onboardingRequestCaptor.capture());
+        OnboardingPaRequest actual = onboardingRequestCaptor.getValue();
+        assertEquals(actual.getInstitution().getTaxCode(), institutionUpdate.getTaxCode());
+        verifyNoMoreInteractions(msOnboardingApiClient);
+    }
+    @Test
+    void onboarding_institutionPsp() {
+        // given
+        OnboardingData onboardingData = new OnboardingData();
+        onboardingData.setTaxCode("taxCode");
+        onboardingData.setInstitutionType(InstitutionType.PSP);
+        Billing billing = mockInstance(new Billing());
+        InstitutionUpdate institutionUpdate = new InstitutionUpdate();
+        institutionUpdate.setTaxCode("taxCode");
+        institutionUpdate.setPaymentServiceProvider(new PaymentServiceProvider());
+        institutionUpdate.setDataProtectionOfficer(new DataProtectionOfficer());
+        onboardingData.setBilling(billing);
+        onboardingData.setUsers(List.of(mockInstance(new User())));
+        onboardingData.setInstitutionUpdate(institutionUpdate);
+        // when
+        onboardingMsConnector.onboarding(onboardingData);
+        // then
+        ArgumentCaptor<OnboardingPspRequest> onboardingRequestCaptor = ArgumentCaptor.forClass(OnboardingPspRequest.class);
+        verify(msOnboardingApiClient, times(1))
+                ._v1OnboardingPspPost(onboardingRequestCaptor.capture());
+        OnboardingPspRequest actual = onboardingRequestCaptor.getValue();
+        assertEquals(actual.getInstitution().getTaxCode(), institutionUpdate.getTaxCode());
+        assertNotNull(actual.getInstitution().getPaymentServiceProvider());
+        assertNotNull(actual.getInstitution().getDataProtectionOfficer());
+        verifyNoMoreInteractions(msOnboardingApiClient);
+    }
+}

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImplTest.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import feign.FeignException;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.commons.utils.TestUtils;
 import it.pagopa.selfcare.onboarding.connector.exceptions.ResourceNotFoundException;
 import it.pagopa.selfcare.onboarding.connector.model.RelationshipInfo;
@@ -23,16 +22,10 @@ import it.pagopa.selfcare.onboarding.connector.model.onboarding.InstitutionUpdat
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.*;
 import it.pagopa.selfcare.onboarding.connector.rest.client.MsCoreOnboardingApiClient;
 import it.pagopa.selfcare.onboarding.connector.rest.client.MsCoreTokenApiClient;
-import it.pagopa.selfcare.onboarding.connector.rest.client.MsOnboardingApiClient;
 import it.pagopa.selfcare.onboarding.connector.rest.client.PartyProcessRestClient;
 import it.pagopa.selfcare.onboarding.connector.rest.mapper.InstitutionMapper;
 import it.pagopa.selfcare.onboarding.connector.rest.mapper.InstitutionMapperImpl;
-import it.pagopa.selfcare.onboarding.connector.rest.mapper.OnboardingMapper;
-import it.pagopa.selfcare.onboarding.connector.rest.mapper.OnboardingMapperImpl;
 import it.pagopa.selfcare.onboarding.connector.rest.model.*;
-import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingDefaultRequest;
-import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingPaRequest;
-import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingPspRequest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,14 +64,8 @@ class PartyConnectorImplTest {
     @Mock
     private MsCoreOnboardingApiClient msCoreOnboardingApiClient;
 
-    @Mock
-    private MsOnboardingApiClient msOnboardingApiClient;
-
     @Spy
     private InstitutionMapper institutionMapper = new InstitutionMapperImpl();
-
-    @Spy
-    private OnboardingMapper onboardingMapper = new OnboardingMapperImpl();
 
     @Captor
     ArgumentCaptor<OnboardingInstitutionRequest> onboardingRequestCaptor;
@@ -151,80 +138,6 @@ class PartyConnectorImplTest {
         assertEquals(onboardingData.getInstitutionExternalId(), request.getInstitutionExternalId());
         assertNull(request.getInstitutionUpdate().getGeographicTaxonomyCodes());
         verifyNoMoreInteractions(restClientMock);
-    }
-
-    @Test
-    void onboarding_institutionDefault() {
-        // given
-        OnboardingData onboardingData = new OnboardingData();
-        onboardingData.setTaxCode("taxCode");
-        onboardingData.setInstitutionType(InstitutionType.GSP);
-        Billing billing = mockInstance(new Billing());
-        InstitutionUpdate institutionUpdate = new InstitutionUpdate();
-        institutionUpdate.setTaxCode("taxCode");
-        onboardingData.setBilling(billing);
-        onboardingData.setUsers(List.of(mockInstance(new User())));
-        onboardingData.setInstitutionUpdate(institutionUpdate);
-        // when
-        partyConnector.onboarding(onboardingData);
-        // then
-
-        ArgumentCaptor<OnboardingDefaultRequest> onboardingRequestCaptor = ArgumentCaptor.forClass(OnboardingDefaultRequest.class);
-        verify(msOnboardingApiClient, times(1))
-                ._onboardingPost(onboardingRequestCaptor.capture());
-        OnboardingDefaultRequest actual = onboardingRequestCaptor.getValue();
-        assertEquals(actual.getInstitution().getTaxCode(), institutionUpdate.getTaxCode());
-        verifyNoMoreInteractions(msOnboardingApiClient);
-    }
-
-    @Test
-    void onboarding_institutionPa() {
-        // given
-        OnboardingData onboardingData = new OnboardingData();
-        onboardingData.setTaxCode("taxCode");
-        onboardingData.setInstitutionType(InstitutionType.PA);
-        Billing billing = mockInstance(new Billing());
-        InstitutionUpdate institutionUpdate = new InstitutionUpdate();
-        institutionUpdate.setTaxCode("taxCode");
-        onboardingData.setBilling(billing);
-        onboardingData.setUsers(List.of(mockInstance(new User())));
-        onboardingData.setInstitutionUpdate(institutionUpdate);
-        // when
-        partyConnector.onboarding(onboardingData);
-        // then
-
-        ArgumentCaptor<OnboardingPaRequest> onboardingRequestCaptor = ArgumentCaptor.forClass(OnboardingPaRequest.class);
-        verify(msOnboardingApiClient, times(1))
-                ._onboardingPaPost(onboardingRequestCaptor.capture());
-        OnboardingPaRequest actual = onboardingRequestCaptor.getValue();
-        assertEquals(actual.getInstitution().getTaxCode(), institutionUpdate.getTaxCode());
-        verifyNoMoreInteractions(msOnboardingApiClient);
-    }
-    @Test
-    void onboarding_institutionPsp() {
-        // given
-        OnboardingData onboardingData = new OnboardingData();
-        onboardingData.setTaxCode("taxCode");
-        onboardingData.setInstitutionType(InstitutionType.PSP);
-        Billing billing = mockInstance(new Billing());
-        InstitutionUpdate institutionUpdate = new InstitutionUpdate();
-        institutionUpdate.setTaxCode("taxCode");
-        institutionUpdate.setPaymentServiceProvider(new PaymentServiceProvider());
-        institutionUpdate.setDataProtectionOfficer(new DataProtectionOfficer());
-        onboardingData.setBilling(billing);
-        onboardingData.setUsers(List.of(mockInstance(new User())));
-        onboardingData.setInstitutionUpdate(institutionUpdate);
-        // when
-        partyConnector.onboarding(onboardingData);
-        // then
-        ArgumentCaptor<OnboardingPspRequest> onboardingRequestCaptor = ArgumentCaptor.forClass(OnboardingPspRequest.class);
-        verify(msOnboardingApiClient, times(1))
-                ._onboardingPspPost(onboardingRequestCaptor.capture());
-        OnboardingPspRequest actual = onboardingRequestCaptor.getValue();
-        assertEquals(actual.getInstitution().getTaxCode(), institutionUpdate.getTaxCode());
-        assertNotNull(actual.getInstitution().getPaymentServiceProvider());
-        assertNotNull(actual.getInstitution().getDataProtectionOfficer());
-        verifyNoMoreInteractions(msOnboardingApiClient);
     }
 
     @Test

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 public interface InstitutionService {
 
-    void onboardingProductAsync(OnboardingData onboardingData);
+    void onboardingProductV2(OnboardingData onboardingData);
 
     void onboardingProduct(OnboardingData onboardingData);
 

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -63,6 +63,9 @@ class InstitutionServiceImpl implements InstitutionService {
     public static final String FIELD_PSP_DATA_IS_REQUIRED_FOR_PSP_INSTITUTION_ONBOARDING = "Field 'pspData' is required for PSP institution onboarding";
     static final String DESCRIPTION_TO_REPLACE_REGEX = " - COMUNE";
 
+
+
+    private final OnboardingMsConnector onboardingMsConnector;
     private final PartyConnector partyConnector;
     private final ProductsConnector productsConnector;
     private final UserRegistryConnector userConnector;
@@ -74,13 +77,14 @@ class InstitutionServiceImpl implements InstitutionService {
 
 
     @Autowired
-    InstitutionServiceImpl(PartyConnector partyConnector,
+    InstitutionServiceImpl(OnboardingMsConnector onboardingMsConnector, PartyConnector partyConnector,
                            ProductsConnector productsConnector,
                            UserRegistryConnector userConnector,
                            MsExternalInterceptorConnector externalInterceptorConnector, MsCoreConnector msCoreConnector,
                            PartyRegistryProxyConnector partyRegistryProxyConnector,
                            OnboardingValidationStrategy onboardingValidationStrategy,
                            InstitutionInfoMapper institutionMapper) {
+        this.onboardingMsConnector = onboardingMsConnector;
         this.partyConnector = partyConnector;
         this.externalInterceptorConnector = externalInterceptorConnector;
         this.partyRegistryProxyConnector = partyRegistryProxyConnector;
@@ -96,7 +100,7 @@ class InstitutionServiceImpl implements InstitutionService {
     public void onboardingProductAsync(OnboardingData onboardingData) {
         log.trace("onboardingProductAsync start");
         log.debug("onboardingProductAsync onboardingData = {}", onboardingData);
-        partyConnector.onboarding(onboardingData);
+        onboardingMsConnector.onboarding(onboardingData);
         log.trace("onboarding end");
     }
 

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -97,7 +97,7 @@ class InstitutionServiceImpl implements InstitutionService {
 
 
     @Override
-    public void onboardingProductAsync(OnboardingData onboardingData) {
+    public void onboardingProductV2(OnboardingData onboardingData) {
         log.trace("onboardingProductAsync start");
         log.debug("onboardingProductAsync onboardingData = {}", onboardingData);
         onboardingMsConnector.onboarding(onboardingData);

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenService.java
@@ -7,5 +7,7 @@ public interface TokenService {
     public void verifyToken(String tokenId);
     public void completeToken(String tokenId, MultipartFile contract);
 
+    void completeTokenAsync(String onboardingId, MultipartFile contract);
+
     void deleteToken(String tokenId);
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenService.java
@@ -7,7 +7,7 @@ public interface TokenService {
     public void verifyToken(String tokenId);
     public void completeToken(String tokenId, MultipartFile contract);
 
-    void completeTokenAsync(String onboardingId, MultipartFile contract);
+    void completeTokenV2(String onboardingId, MultipartFile contract);
 
     void deleteToken(String tokenId);
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenServiceImpl.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.onboarding.core;
 
+import it.pagopa.selfcare.onboarding.connector.api.OnboardingMsConnector;
 import it.pagopa.selfcare.onboarding.connector.api.PartyConnector;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,8 +13,11 @@ public class TokenServiceImpl implements TokenService {
 
     private final PartyConnector partyConnector;
 
-    public TokenServiceImpl(PartyConnector partyConnector) {
+    private final OnboardingMsConnector onboardingMsConnector;
+
+    public TokenServiceImpl(PartyConnector partyConnector, OnboardingMsConnector onboardingMsConnector) {
         this.partyConnector = partyConnector;
+        this.onboardingMsConnector = onboardingMsConnector;
     }
 
     @Override
@@ -34,6 +38,16 @@ public class TokenServiceImpl implements TokenService {
         partyConnector.onboardingTokenComplete(tokenId, contract);
         log.debug("completeToken result = success");
         log.trace("completeToken end");
+    }
+
+    @Override
+    public void completeTokenAsync(String onboardingId, MultipartFile contract) {
+        log.trace("completeTokenAsync start");
+        log.debug("completeTokenAsync id = {}", onboardingId);
+        Assert.notNull(onboardingId, "TokenId is required");
+        onboardingMsConnector.onboardingTokenComplete(onboardingId, contract);
+        log.debug("completeTokenAsync result = success");
+        log.trace("completeTokenAsync end");
     }
 
     @Override

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenServiceImpl.java
@@ -41,7 +41,7 @@ public class TokenServiceImpl implements TokenService {
     }
 
     @Override
-    public void completeTokenAsync(String onboardingId, MultipartFile contract) {
+    public void completeTokenV2(String onboardingId, MultipartFile contract) {
         log.trace("completeTokenAsync start");
         log.debug("completeTokenAsync id = {}", onboardingId);
         Assert.notNull(onboardingId, "TokenId is required");

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -466,7 +466,7 @@ class InstitutionServiceImplTest {
         onboardingData.setInstitutionType(InstitutionType.PA);
         onboardingData.setUsers(List.of(dummyManager, dummyDelegate));
         // when
-        institutionService.onboardingProductAsync(onboardingData);
+        institutionService.onboardingProductV2(onboardingData);
         // then
         verify(onboardingMsConnector, times(1))
                 .onboarding(any());

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -63,6 +63,9 @@ class InstitutionServiceImplTest {
     private PartyConnector partyConnectorMock;
 
     @Mock
+    private OnboardingMsConnector onboardingMsConnector;
+
+    @Mock
     private ProductsConnector productsConnectorMock;
 
     @Mock
@@ -465,7 +468,7 @@ class InstitutionServiceImplTest {
         // when
         institutionService.onboardingProductAsync(onboardingData);
         // then
-        verify(partyConnectorMock, times(1))
+        verify(onboardingMsConnector, times(1))
                 .onboarding(any());
     }
 

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/TokenServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/TokenServiceImplTest.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.onboarding.core;
 
 
+import it.pagopa.selfcare.onboarding.connector.api.OnboardingMsConnector;
 import it.pagopa.selfcare.onboarding.connector.api.PartyConnector;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,9 @@ public class TokenServiceImplTest {
 
     @Mock
     private PartyConnector partyConnector;
+
+    @Mock
+    private OnboardingMsConnector onboardingMsConnector;
 
     @Test
     void shouldNotVerifyTokenWhenIdIsNull() {
@@ -75,6 +79,28 @@ public class TokenServiceImplTest {
         tokenService.completeToken(tokenId, mockMultipartFile);
         //then
         Mockito.verify(partyConnector, Mockito.times(1))
+                .onboardingTokenComplete(tokenId, mockMultipartFile);
+    }
+
+    @Test
+    void shouldNotCompleteTokenV2WhenIdIsNull() {
+        Executable executable = () -> tokenService.completeTokenV2(null, null);
+        //then
+        Exception e = Assertions.assertThrows(IllegalArgumentException.class, executable);
+        Assertions.assertEquals("TokenId is required", e.getMessage());
+        Mockito.verifyNoInteractions(partyConnector);
+    }
+
+    @Test
+    void shouldCompleteTokenV2() throws IOException {
+        //given
+        String tokenId = "example";
+        MockMultipartFile mockMultipartFile = new MockMultipartFile("example", new ByteArrayInputStream("example".getBytes(StandardCharsets.UTF_8)));
+        doNothing().when(onboardingMsConnector).onboardingTokenComplete(anyString(), any());
+        // when
+        tokenService.completeTokenV2(tokenId, mockMultipartFile);
+        //then
+        Mockito.verify(onboardingMsConnector, Mockito.times(1))
                 .onboardingTokenComplete(tokenId, mockMultipartFile);
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
@@ -71,13 +71,10 @@ public class InstitutionController {
     @PostMapping(value = "/onboarding")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.onboarding.subunit}")
-    public void onboarding(@RequestBody @Valid OnboardingProductDto request, @RequestParam(value = "mode", required = false) OnboardingMode mode) {
+    public void onboarding(@RequestBody @Valid OnboardingProductDto request) {
         log.trace(ONBOARDING_START);
         log.debug("onboarding request = {}", request);
-        if(Objects.isNull(mode) || mode.equals(OnboardingMode.SYNC))
-            institutionService.onboardingProduct(onboardingResourceMapper.toEntity(request));
-        else institutionService.onboardingProductAsync(onboardingResourceMapper.toEntity(request));
-
+        institutionService.onboardingProduct(onboardingResourceMapper.toEntity(request));
         log.trace(ONBOARDING_END);
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
@@ -1,0 +1,57 @@
+package it.pagopa.selfcare.onboarding.web.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import it.pagopa.selfcare.commons.web.model.Problem;
+import it.pagopa.selfcare.onboarding.core.InstitutionService;
+import it.pagopa.selfcare.onboarding.web.model.OnboardingProductDto;
+import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
+
+@Slf4j
+@RestController
+@RequestMapping(value = "/v2/institutions", produces = MediaType.APPLICATION_JSON_VALUE)
+@Api(tags = "institutions")
+public class InstitutionV2Controller {
+
+    private final InstitutionService institutionService;
+    private final OnboardingResourceMapper onboardingResourceMapper;
+
+    private static final String ONBOARDING_START = "onboarding start";
+    private static final String ONBOARDING_END = "onboarding end";
+
+    @Autowired
+    public InstitutionV2Controller(InstitutionService institutionService, OnboardingResourceMapper onboardingResourceMapper) {
+        this.institutionService = institutionService;
+        this.onboardingResourceMapper = onboardingResourceMapper;
+    }
+
+
+    @ApiResponse(responseCode = "403",
+            description = "Forbidden",
+            content = {
+                    @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE,
+                            schema = @Schema(implementation = Problem.class))
+            })
+    @PostMapping(value = "/onboarding")
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.onboarding.subunit}")
+    public void onboarding(@RequestBody @Valid OnboardingProductDto request) {
+        log.trace(ONBOARDING_START);
+        log.debug("onboarding request = {}", request);
+        institutionService.onboardingProductV2(onboardingResourceMapper.toEntity(request));
+        log.trace(ONBOARDING_END);
+    }
+
+}

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenController.java
@@ -6,7 +6,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.onboarding.core.TokenService;
-import it.pagopa.selfcare.onboarding.web.model.OnboardingMode;
 import it.pagopa.selfcare.onboarding.web.model.TokenVerifyResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -14,8 +13,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.Objects;
 
 @Slf4j
 @RestController
@@ -65,13 +62,10 @@ public class TokenController {
     @PostMapping(value = "/{tokenId}/complete")
     public ResponseEntity<Void> complete(@ApiParam("${swagger.tokens.tokenId}")
                                                    @PathVariable(value = "tokenId") String tokenId,
-                                                   @RequestPart MultipartFile contract,
-                                                    @RequestParam(value = "mode", required = false) OnboardingMode mode) {
+                                                   @RequestPart MultipartFile contract) {
         log.trace("complete Token start");
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "complete Token tokenId = {}, contract = {}", tokenId, contract);
-        if(Objects.isNull(mode) || mode.equals(OnboardingMode.SYNC))
-            tokenService.completeToken(tokenId, contract);
-        else tokenService.completeTokenAsync(tokenId, contract);
+        tokenService.completeToken(tokenId, contract);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenController.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.onboarding.core.TokenService;
+import it.pagopa.selfcare.onboarding.web.model.OnboardingMode;
 import it.pagopa.selfcare.onboarding.web.model.TokenVerifyResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -13,6 +14,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Objects;
 
 @Slf4j
 @RestController
@@ -62,10 +65,13 @@ public class TokenController {
     @PostMapping(value = "/{tokenId}/complete")
     public ResponseEntity<Void> complete(@ApiParam("${swagger.tokens.tokenId}")
                                                    @PathVariable(value = "tokenId") String tokenId,
-                                                   @RequestPart MultipartFile contract) {
+                                                   @RequestPart MultipartFile contract,
+                                                    @RequestParam(value = "mode", required = false) OnboardingMode mode) {
         log.trace("complete Token start");
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "complete Token tokenId = {}, contract = {}", tokenId, contract);
-        tokenService.completeToken(tokenId, contract);
+        if(Objects.isNull(mode) || mode.equals(OnboardingMode.SYNC))
+            tokenService.completeToken(tokenId, contract);
+        else tokenService.completeTokenAsync(tokenId, contract);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -1,0 +1,52 @@
+package it.pagopa.selfcare.onboarding.web.controller;
+
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import it.pagopa.selfcare.commons.base.logging.LogUtils;
+import it.pagopa.selfcare.onboarding.core.TokenService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequestMapping(value = "/v2/tokens", produces = MediaType.APPLICATION_JSON_VALUE)
+@Api(tags = "tokens")
+public class TokenV2Controller {
+
+    private final TokenService tokenService;
+
+    public TokenV2Controller(TokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    /**
+     * The function perform complete operation of an onboarding request receiving onboarding id and contract signed by hte institution.
+     * It checks the contract's signature and upload the contract on an azure storage
+     * At the end, function triggers async activities related to complete onboarding
+     * that consist of create the institution, activate the onboarding and sending data to notification queue
+     *
+     * @param onboardingId String
+     * @param contract MultipartFile
+     * @return no content
+     * * Code: 204, Message: successful operation, DataType: TokenId
+     * * Code: 400, Message: Invalid ID supplied, DataType: Problem
+     * * Code: 404, Message: Not found, DataType: Problem
+     */
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ApiOperation(value = "${swagger.tokens.complete}", notes = "${swagger.tokens.complete}")
+    @PostMapping(value = "/{onboardingId}/complete")
+    public ResponseEntity<Void> complete(@ApiParam("${swagger.tokens.tokenId}")
+                                                   @PathVariable(value = "onboardingId") String onboardingId,
+                                                   @RequestPart MultipartFile contract) {
+        log.trace("complete Token start");
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "complete Token tokenId = {}, contract = {}", onboardingId, contract);
+        tokenService.completeTokenV2(onboardingId, contract);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingMode.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingMode.java
@@ -1,6 +1,0 @@
-package it.pagopa.selfcare.onboarding.web.model;
-
-public enum OnboardingMode {
-
-    SYNC, ASYNC
-}

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionControllerTest.java
@@ -109,27 +109,6 @@ class InstitutionControllerTest {
 
 
     @Test
-    void onboardingProductAsync(@Value("classpath:stubs/onboardingProductsDtoWithoutGeo.json") Resource onboardingDto) throws Exception {
-        // given
-        String institutionId = "institutionId";
-        String productId = "productId";
-        // when
-        mvc.perform(MockMvcRequestBuilders
-                        .post(BASE_URL + "/onboarding", institutionId, productId)
-                        .param("mode", OnboardingMode.ASYNC.toString())
-                        .content(onboardingDto.getInputStream().readAllBytes())
-                        .contentType(APPLICATION_JSON_VALUE)
-                        .accept(APPLICATION_JSON_VALUE))
-                .andExpect(status().isCreated())
-                .andExpect(content().string(emptyString()));
-        // then
-        verify(institutionServiceMock, times(1))
-                .onboardingProductAsync(any(OnboardingData.class));
-        verifyNoMoreInteractions(institutionServiceMock);
-    }
-
-
-    @Test
     void onboardingCompany(@Value("classpath:stubs/onboardingCompanyDto.json") Resource onboardingDto) throws Exception {
 
         // when

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2ControllerTest.java
@@ -1,0 +1,55 @@
+package it.pagopa.selfcare.onboarding.web.controller;
+
+import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
+import it.pagopa.selfcare.onboarding.core.InstitutionService;
+import it.pagopa.selfcare.onboarding.web.config.WebTestConfig;
+import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingInstitutionInfoMapperImpl;
+import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapperImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.hamcrest.Matchers.emptyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+@WebMvcTest(value = {InstitutionV2Controller.class}, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@ContextConfiguration(classes = {InstitutionV2Controller.class, WebTestConfig.class, OnboardingResourceMapperImpl.class, OnboardingInstitutionInfoMapperImpl.class})
+public class InstitutionV2ControllerTest {
+
+    private static final String BASE_URL = "/v2/institutions";
+
+    @Autowired
+    protected MockMvc mvc;
+
+    @MockBean
+    private InstitutionService institutionServiceMock;
+
+    @Test
+    void onboardingProductAsync(@Value("classpath:stubs/onboardingProductsDtoWithoutGeo.json") Resource onboardingDto) throws Exception {
+        // given
+        String institutionId = "institutionId";
+        String productId = "productId";
+        // when
+        mvc.perform(MockMvcRequestBuilders
+                        .post(BASE_URL + "/onboarding", institutionId, productId)
+                        .content(onboardingDto.getInputStream().readAllBytes())
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().isCreated())
+                .andExpect(content().string(emptyString()));
+        // then
+        verify(institutionServiceMock, times(1))
+                .onboardingProductV2(any(OnboardingData.class));
+        verifyNoMoreInteractions(institutionServiceMock);
+    }
+}

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2ControllerTest.java
@@ -1,0 +1,43 @@
+package it.pagopa.selfcare.onboarding.web.controller;
+
+
+import it.pagopa.selfcare.onboarding.core.TokenService;
+import it.pagopa.selfcare.onboarding.web.config.WebTestConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.multipart.MultipartFile;
+
+@WebMvcTest(value = {TokenV2Controller.class}, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@ContextConfiguration(classes = {TokenV2Controller.class, WebTestConfig.class})
+public class TokenV2ControllerTest {
+
+    @Autowired
+    protected MockMvc mvc;
+
+    @MockBean
+    private TokenService tokenService;
+
+    /**
+     * Method under test: {@link TokenController#complete(String, MultipartFile)}
+     */
+    @Test
+    void shouldCompleteToken() throws Exception {
+
+        MockMultipartFile file = new MockMultipartFile("contract", "".getBytes());
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .multipart("/v2/tokens/{tokenId}/complete",
+                        "42")
+                .file(file);
+        mvc.perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+    }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* Added **TokenV2Controller** which implements the new call to onboarding-ms for '_onboarding complete_'.
* Added **InstitutionV2Controller** which implements the new call to onboarding-ms for '_onboarding_'.
* Remove OnboardingMove because it is replaced with new endpoint for invoking new onboarding complete

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This change is required to integrate the new onboarding flow with the onboarding-ms service. The introduction of **TokenV2Controller** and **InstitutionV2Controller** is crucial for implementing the new logic while maintaining backward compatibility. The new endpoints in these controllers will handle the updated onboarding process, ensuring a seamless transition to the new system without disrupting existing functionality.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.