### PR TITLE
[SELC-3509] feat: using new endpoints V2 for Onboarding Process Verification

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2084,6 +2084,89 @@
         } ]
       }
     },
+    "/v2/tokens/{onboardingId}/verify" : {
+      "post" : {
+        "tags" : [ "tokens" ],
+        "summary" : "Verify if the token is already consumed",
+        "description" : "Verify if the token is already consumed",
+        "operationId" : "verifyOnboardingUsingPOST",
+        "parameters" : [ {
+          "name" : "onboardingId",
+          "in" : "path",
+          "description" : "Contract's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/TokenVerifyResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/v1/users/validate" : {
       "post" : {
         "tags" : [ "user" ],

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
@@ -7,4 +7,6 @@ public interface OnboardingMsConnector {
     void onboarding(OnboardingData onboardingData);
 
     void onboardingTokenComplete(String onboardingId, MultipartFile contract);
+
+    void onboardingPending(String onboardingId);
 }

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -6,6 +6,78 @@
   },
   "paths" : {
     "/v1/onboarding" : {
+      "get" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "The API retrieves paged onboarding using optional filter, order by descending creation date",
+        "parameters" : [ {
+          "name" : "from",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "schema" : {
+            "format" : "int32",
+            "default" : "0",
+            "type" : "integer"
+          }
+        }, {
+          "name" : "productId",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "schema" : {
+            "format" : "int32",
+            "default" : "20",
+            "type" : "integer"
+          }
+        }, {
+          "name" : "status",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "taxCode",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "to",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OnboardingGetResponse"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      },
       "post" : {
         "tags" : [ "Onboarding Controller" ],
         "summary" : "Perform default onboarding request, it is used for GSP/SA/AS institution type.Users data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding based on institution type.",
@@ -29,11 +101,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -65,11 +137,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -101,11 +173,46 @@
               }
             }
           },
+          "403" : {
+            "description" : "Not Allowed"
+          },
           "401" : {
             "description" : "Not Authorized"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/v1/onboarding/{onboardingId}" : {
+      "get" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "Retrieve an onboarding record given its ID",
+        "parameters" : [ {
+          "name" : "onboardingId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OnboardingGet"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -129,13 +236,11 @@
           "content" : {
             "multipart/form-data" : {
               "schema" : {
-                "required" : [ "contract" ],
                 "type" : "object",
                 "properties" : {
                   "contract" : {
-                    "type" : "string",
-                    "description" : "contract",
-                    "format" : "binary"
+                    "format" : "binary",
+                    "type" : "string"
                   }
                 }
               }
@@ -149,11 +254,76 @@
               "application/json" : { }
             }
           },
+          "403" : {
+            "description" : "Not Allowed"
+          },
           "401" : {
             "description" : "Not Authorized"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/v1/onboarding/{onboardingId}/delete" : {
+      "put" : {
+        "tags" : [ "Onboarding Controller" ],
+        "parameters" : [ {
+          "name" : "onboardingId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : { }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/v1/onboarding/{onboardingId}/pending" : {
+      "get" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "Returns an onboarding record by its ID only if its status is PENDING. This feature is crucial for ensuring that the onboarding process can be completed only when the onboarding status is appropriately set to PENDING.",
+        "parameters" : [ {
+          "name" : "onboardingId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OnboardingGet"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -496,6 +666,59 @@
           },
           "billing" : {
             "$ref" : "#/components/schemas/BillingRequest"
+          }
+        }
+      },
+      "OnboardingGet" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "productId" : {
+            "type" : "string"
+          },
+          "workflowType" : {
+            "type" : "string"
+          },
+          "institution" : {
+            "$ref" : "#/components/schemas/InstitutionResponse"
+          },
+          "users" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/UserResponse"
+            }
+          },
+          "pricingPlan" : {
+            "type" : "string"
+          },
+          "billing" : {
+            "$ref" : "#/components/schemas/BillingResponse"
+          },
+          "signContract" : {
+            "type" : "boolean"
+          },
+          "status" : {
+            "type" : "string"
+          },
+          "userRequestUid" : {
+            "type" : "string"
+          }
+        }
+      },
+      "OnboardingGetResponse" : {
+        "type" : "object",
+        "properties" : {
+          "count" : {
+            "format" : "int64",
+            "type" : "integer"
+          },
+          "items" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OnboardingGet"
+            }
           }
         }
       },

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
@@ -39,4 +39,9 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
     public void onboardingTokenComplete(String onboardingId, MultipartFile contract) {
         msOnboardingApiClient._v1OnboardingOnboardingIdCompletePut(onboardingId, contract);
     }
+
+    @Override
+    public void onboardingPending(String onboardingId) {
+        msOnboardingApiClient._v1OnboardingOnboardingIdPendingGet(onboardingId);
+    }
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
@@ -128,4 +128,17 @@ public class OnboardingMsConnectorImplTest {
                 ._v1OnboardingOnboardingIdCompletePut(tokenId, mockMultipartFile);
         verifyNoMoreInteractions(msOnboardingApiClient);
     }
+
+    @Test
+    void onboardingPending() {
+        // given
+        final String onboardingId = "onboardingId";
+        // when
+        final Executable executable = () -> onboardingMsConnector.onboardingPending(onboardingId);
+        // then
+        assertDoesNotThrow(executable);
+        verify(msOnboardingApiClient, times(1))
+                ._v1OnboardingOnboardingIdPendingGet(onboardingId);
+        verifyNoMoreInteractions(msOnboardingApiClient);
+    }
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenService.java
@@ -5,6 +5,9 @@ import org.springframework.web.multipart.MultipartFile;
 public interface TokenService {
 
     public void verifyToken(String tokenId);
+
+    void verifyOnboarding(String onboardingId);
+
     public void completeToken(String tokenId, MultipartFile contract);
 
     void completeTokenV2(String onboardingId, MultipartFile contract);

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenServiceImpl.java
@@ -31,6 +31,16 @@ public class TokenServiceImpl implements TokenService {
     }
 
     @Override
+    public void verifyOnboarding(String onboardingId) {
+        log.trace("verifyOnboarding start");
+        log.debug("verifyOnboarding id = {}", onboardingId);
+        Assert.notNull(onboardingId, "OnboardingId is required");
+        onboardingMsConnector.onboardingPending(onboardingId);
+        log.debug("verifyOnboarding result = success");
+        log.trace("verifyOnboarding end");
+    }
+
+    @Override
     public void completeToken(String tokenId, MultipartFile contract) {
         log.trace("completeToken start");
         log.debug("completeToken id = {}", tokenId);

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/TokenServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/TokenServiceImplTest.java
@@ -105,6 +105,17 @@ public class TokenServiceImplTest {
     }
 
     @Test
+    void onboardingPending() {
+        //given
+        final String onboardingId = "onboardingId";
+        // when
+        tokenService.verifyOnboarding(onboardingId);
+        //then
+        Mockito.verify(onboardingMsConnector, Mockito.times(1))
+                .onboardingPending(onboardingId);
+    }
+
+    @Test
     void shouldDeleteToken() {
         //given
         String tokenId = "example";

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.onboarding.core.TokenService;
+import it.pagopa.selfcare.onboarding.web.model.TokenVerifyResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -48,5 +49,26 @@ public class TokenV2Controller {
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "complete Token tokenId = {}, contract = {}", onboardingId, contract);
         tokenService.completeTokenV2(onboardingId, contract);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    /**
+     * The verifyOnboarding function is used to verify the onboarding has already consumed.
+     * It takes in a String onboarding and returns a Token object.
+     *
+     * @param onboardingId onboardingId
+     * @return The onboardingId
+     * * Code: 200, Message: successful operation, DataType: TokenId
+     * * Code: 400, Message: Invalid ID supplied, DataType: Problem
+     * * Code: 404, Message: Token not found, DataType: Problem
+     * * Code: 409, Message: Token already consumed, DataType: Problem
+     */
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "${swagger.tokens.verify}", notes = "${swagger.tokens.verify}")
+    @PostMapping("/{onboardingId}/verify")
+    public ResponseEntity<TokenVerifyResponse> verifyOnboarding(@ApiParam("${swagger.tokens.tokenId}")
+                                                           @PathVariable("onboardingId") String onboardingId) {
+        log.debug("Verify token identified with {}", onboardingId);
+        tokenService.verifyOnboarding(onboardingId);
+        return ResponseEntity.ok().body(TokenVerifyResponse.builder().id(onboardingId).build());
     }
 }

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2ControllerTest.java
@@ -16,6 +16,12 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @WebMvcTest(value = {TokenV2Controller.class}, excludeAutoConfiguration = SecurityAutoConfiguration.class)
 @ContextConfiguration(classes = {TokenV2Controller.class, WebTestConfig.class})
 public class TokenV2ControllerTest {
@@ -27,7 +33,7 @@ public class TokenV2ControllerTest {
     private TokenService tokenService;
 
     /**
-     * Method under test: {@link TokenController#complete(String, MultipartFile)}
+     * Method under test: {@link TokenV2Controller#complete(String, MultipartFile)}
      */
     @Test
     void shouldCompleteToken() throws Exception {
@@ -39,5 +45,25 @@ public class TokenV2ControllerTest {
                 .file(file);
         mvc.perform(requestBuilder)
                 .andExpect(MockMvcResultMatchers.status().isNoContent());
+    }
+
+    /**
+     * Method under test: {@link TokenV2Controller#verifyOnboarding(String)}
+     */
+    @Test
+    void verifyOnboarding() throws Exception {
+
+        String onboardingId = UUID.randomUUID().toString();
+        doNothing().when(tokenService).verifyOnboarding(onboardingId);
+
+        //when
+        mvc.perform(MockMvcRequestBuilders
+                        .post("/v2/tokens/{onboardingId}/verify", onboardingId)
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
+        //then
+        verify(tokenService, times(1))
+                .verifyOnboarding(onboardingId);
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

**Verify Endpoint V2 using new Onboarding**: Added a new endpoint /v2/tokens/{onboardingId}/verify that returns an onboardingId record by its ID only if its status is PENDING otherwise it will return 404. This feature is crucial for ensuring that the onboarding process can be completed only when the onboarding status is appropriately set to PENDING.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The addition of this endpoints is driven by the need for the front-end to effectively verify the status of an onboarding process using new onboarding services. This endpoint ensures that the onboarding process adheres to the necessary workflow, where completion is contingent upon the onboarding status being PENDING. 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.