### PR TITLE
[SELC-3493] feat: add new endpoint for onboarding process verification by admin

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1991,6 +1991,79 @@
         } ]
       }
     },
+    "/v2/tokens/{onboardingId}" : {
+      "get" : {
+        "tags" : [ "tokens" ],
+        "summary" : "retrieveOnboardingRequest",
+        "description" : "Service to retrieve a specific onboarding request",
+        "operationId" : "retrieveOnboardingRequestUsingGET",
+        "parameters" : [ {
+          "name" : "onboardingId",
+          "in" : "path",
+          "description" : "Onboarding's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OnboardingRequestResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/v2/tokens/{onboardingId}/complete" : {
       "post" : {
         "tags" : [ "tokens" ],
@@ -2000,7 +2073,7 @@
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",
-          "description" : "Contract's unique identifier",
+          "description" : "Onboarding's unique identifier",
           "required" : true,
           "style" : "simple",
           "schema" : {
@@ -2093,7 +2166,7 @@
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",
-          "description" : "Contract's unique identifier",
+          "description" : "Onboarding's unique identifier",
           "required" : true,
           "style" : "simple",
           "schema" : {
@@ -2497,6 +2570,29 @@
           }
         }
       },
+      "DpoData" : {
+        "title" : "DpoData",
+        "required" : [ "address", "email", "pec" ],
+        "type" : "object",
+        "properties" : {
+          "address" : {
+            "type" : "string",
+            "description" : "DPO's address"
+          },
+          "email" : {
+            "type" : "string",
+            "description" : "DPO's email",
+            "format" : "email",
+            "example" : "email@example.com"
+          },
+          "pec" : {
+            "type" : "string",
+            "description" : "DPO's PEC",
+            "format" : "email",
+            "example" : "email@example.com"
+          }
+        }
+      },
       "DpoDataDto" : {
         "title" : "DpoDataDto",
         "required" : [ "address", "email", "pec" ],
@@ -2588,6 +2684,70 @@
           },
           "origin" : {
             "type" : "string"
+          }
+        }
+      },
+      "InstitutionInfo" : {
+        "title" : "InstitutionInfo",
+        "required" : [ "address", "fiscalCode", "id", "institutionType", "mailAddress", "name", "recipientCode", "vatNumber", "zipCode" ],
+        "type" : "object",
+        "properties" : {
+          "address" : {
+            "type" : "string",
+            "description" : "Institution's physical address"
+          },
+          "city" : {
+            "type" : "string",
+            "description" : "Institution's city"
+          },
+          "country" : {
+            "type" : "string",
+            "description" : "Institution's country"
+          },
+          "county" : {
+            "type" : "string",
+            "description" : "Institution's county"
+          },
+          "dpoData" : {
+            "description" : "Data Protection Officer (DPO) specific data",
+            "$ref" : "#/components/schemas/DpoData"
+          },
+          "fiscalCode" : {
+            "type" : "string",
+            "description" : "Institution's taxCode"
+          },
+          "id" : {
+            "type" : "string",
+            "description" : "Institution's unique internal Id"
+          },
+          "institutionType" : {
+            "type" : "string",
+            "description" : "Institution's type",
+            "enum" : [ "AS", "GSP", "PA", "PG", "PSP", "PT", "SA", "SCP" ]
+          },
+          "mailAddress" : {
+            "type" : "string",
+            "description" : "Institution's digitalAddress"
+          },
+          "name" : {
+            "type" : "string",
+            "description" : "Institution's legal name"
+          },
+          "pspData" : {
+            "description" : "Payment Service Provider (PSP) specific data",
+            "$ref" : "#/components/schemas/PspData"
+          },
+          "recipientCode" : {
+            "type" : "string",
+            "description" : "Billing recipient code, not required only for institutionType SA"
+          },
+          "vatNumber" : {
+            "type" : "string",
+            "description" : "Institution's VAT number"
+          },
+          "zipCode" : {
+            "type" : "string",
+            "description" : "Institution's zipCode"
           }
         }
       },
@@ -2877,6 +3037,32 @@
           }
         }
       },
+      "OnboardingRequestResource" : {
+        "title" : "OnboardingRequestResource",
+        "required" : [ "institutionInfo", "manager", "status" ],
+        "type" : "object",
+        "properties" : {
+          "admins" : {
+            "type" : "array",
+            "description" : "Administrators specific data",
+            "items" : {
+              "$ref" : "#/components/schemas/UserInfo"
+            }
+          },
+          "institutionInfo" : {
+            "description" : "Institution specific data",
+            "$ref" : "#/components/schemas/InstitutionInfo"
+          },
+          "manager" : {
+            "description" : "Manager specific data. It's required when institutionType is not PT",
+            "$ref" : "#/components/schemas/UserInfo"
+          },
+          "status" : {
+            "type" : "string",
+            "description" : "Onboarding request's status"
+          }
+        }
+      },
       "Problem" : {
         "title" : "Problem",
         "required" : [ "status", "title" ],
@@ -2934,6 +3120,34 @@
           "title" : {
             "type" : "string",
             "description" : "Product's title"
+          }
+        }
+      },
+      "PspData" : {
+        "title" : "PspData",
+        "required" : [ "abiCode", "businessRegisterNumber", "legalRegisterName", "legalRegisterNumber", "vatNumberGroup" ],
+        "type" : "object",
+        "properties" : {
+          "abiCode" : {
+            "type" : "string",
+            "description" : "PSP's ABI code"
+          },
+          "businessRegisterNumber" : {
+            "type" : "string",
+            "description" : "PSP's Business Register number"
+          },
+          "legalRegisterName" : {
+            "type" : "string",
+            "description" : "PSP's legal register name"
+          },
+          "legalRegisterNumber" : {
+            "type" : "string",
+            "description" : "PSP's legal register number"
+          },
+          "vatNumberGroup" : {
+            "type" : "boolean",
+            "description" : "PSP's Vat Number group",
+            "example" : false
           }
         }
       },
@@ -3022,6 +3236,34 @@
           "taxCode" : {
             "type" : "string",
             "description" : "User's fiscal code"
+          }
+        }
+      },
+      "UserInfo" : {
+        "title" : "UserInfo",
+        "required" : [ "email", "fiscalCode", "id", "name", "surname" ],
+        "type" : "object",
+        "properties" : {
+          "email" : {
+            "type" : "string",
+            "description" : "User's institutional email"
+          },
+          "fiscalCode" : {
+            "type" : "string",
+            "description" : "User's fiscal code"
+          },
+          "id" : {
+            "type" : "string",
+            "description" : "User's unique identifier",
+            "format" : "uuid"
+          },
+          "name" : {
+            "type" : "string",
+            "description" : "User's name"
+          },
+          "surname" : {
+            "type" : "string",
+            "description" : "User's surname"
           }
         }
       },

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
@@ -9,4 +9,8 @@ public interface OnboardingMsConnector {
     void onboardingTokenComplete(String onboardingId, MultipartFile contract);
 
     void onboardingPending(String onboardingId);
+
+    OnboardingData getOnboarding(String onboardingId);
+
+    OnboardingData getOnboardingWithUserInfo(String onboardingId);
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/OnboardingData.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/OnboardingData.java
@@ -30,6 +30,7 @@ public class OnboardingData {
     private String subunitType;
     private String productId;
     private String productName;
+    private String status;
     private List<User> users;
     private String contractPath;
     private String contractVersion;

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -330,6 +330,41 @@
           "SecurityScheme" : [ ]
         } ]
       }
+    },
+    "/v1/onboarding/{onboardingId}/withUserInfo" : {
+      "get" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "Retrieve an onboarding record given its ID adding to user sensitive information",
+        "parameters" : [ {
+          "name" : "onboardingId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OnboardingGet"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
     }
   },
   "components" : {
@@ -408,6 +443,17 @@
           }
         }
       },
+      "GeographicTaxonomyDto" : {
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "type" : "string"
+          },
+          "desc" : {
+            "type" : "string"
+          }
+        }
+      },
       "InstitutionBaseRequest" : {
         "required" : [ "institutionType", "taxCode", "digitalAddress" ],
         "type" : "object",
@@ -450,10 +496,10 @@
           "zipCode" : {
             "type" : "string"
           },
-          "geographicTaxonomyCodes" : {
+          "geographicTaxonomies" : {
             "type" : "array",
             "items" : {
-              "type" : "string"
+              "$ref" : "#/components/schemas/GeographicTaxonomyDto"
             }
           },
           "rea" : {
@@ -522,10 +568,10 @@
           "zipCode" : {
             "type" : "string"
           },
-          "geographicTaxonomyCodes" : {
+          "geographicTaxonomies" : {
             "type" : "array",
             "items" : {
-              "type" : "string"
+              "$ref" : "#/components/schemas/GeographicTaxonomyDto"
             }
           },
           "rea" : {
@@ -593,10 +639,10 @@
           "zipCode" : {
             "type" : "string"
           },
-          "geographicTaxonomyCodes" : {
+          "geographicTaxonomies" : {
             "type" : "array",
             "items" : {
-              "type" : "string"
+              "$ref" : "#/components/schemas/GeographicTaxonomyDto"
             }
           },
           "rea" : {

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
@@ -5,6 +5,7 @@ import it.pagopa.selfcare.onboarding.connector.api.OnboardingMsConnector;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
 import it.pagopa.selfcare.onboarding.connector.rest.client.MsOnboardingApiClient;
 import it.pagopa.selfcare.onboarding.connector.rest.mapper.OnboardingMapper;
+import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingGet;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -43,5 +44,17 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
     @Override
     public void onboardingPending(String onboardingId) {
         msOnboardingApiClient._v1OnboardingOnboardingIdPendingGet(onboardingId);
+    }
+
+    @Override
+    public OnboardingData getOnboarding(String onboardingId) {
+        OnboardingGet onboardingGet = msOnboardingApiClient._v1OnboardingOnboardingIdGet(onboardingId).getBody();
+        return onboardingMapper.toOnboardingData(onboardingGet);
+    }
+
+    @Override
+    public OnboardingData getOnboardingWithUserInfo(String onboardingId) {
+        OnboardingGet onboardingGet = msOnboardingApiClient._v1OnboardingOnboardingIdWithUserInfoGet(onboardingId).getBody();
+        return onboardingMapper.toOnboardingData(onboardingGet);
     }
 }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/OnboardingMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/OnboardingMapper.java
@@ -24,6 +24,7 @@ public interface OnboardingMapper {
     @Mapping(target = "institution", source = ".", qualifiedByName = "toInstitutionBase")
     OnboardingDefaultRequest toOnboardingDefaultRequest(OnboardingData onboardingData);
 
+    GeographicTaxonomyDto toGeographicTaxonomyDto(GeographicTaxonomy geographicTaxonomy);
 
     @Named("toInstitutionBase")
     default InstitutionBaseRequest toInstitutionBase(OnboardingData onboardingData) {
@@ -44,9 +45,9 @@ public interface OnboardingMapper {
         institution.digitalAddress(onboardingData.getInstitutionUpdate().getDigitalAddress());
         institution.address(onboardingData.getInstitutionUpdate().getAddress());
         institution.zipCode(onboardingData.getInstitutionUpdate().getZipCode());
-        institution.geographicTaxonomyCodes(Optional.ofNullable(onboardingData.getInstitutionUpdate().getGeographicTaxonomies())
+        institution.geographicTaxonomies(Optional.ofNullable(onboardingData.getInstitutionUpdate().getGeographicTaxonomies())
                 .map(geotaxes -> geotaxes.stream()
-                        .map(GeographicTaxonomy::getCode)
+                        .map(this::toGeographicTaxonomyDto)
                         .collect(Collectors.toList()))
                 .orElse(null));
         institution.rea(onboardingData.getInstitutionUpdate().getRea());
@@ -79,9 +80,9 @@ public interface OnboardingMapper {
         institutionPsp.digitalAddress(onboardingData.getInstitutionUpdate().getDigitalAddress());
         institutionPsp.address(onboardingData.getInstitutionUpdate().getAddress());
         institutionPsp.zipCode(onboardingData.getInstitutionUpdate().getZipCode());
-        institutionPsp.geographicTaxonomyCodes(Optional.ofNullable(onboardingData.getInstitutionUpdate().getGeographicTaxonomies())
+        institutionPsp.geographicTaxonomies(Optional.ofNullable(onboardingData.getInstitutionUpdate().getGeographicTaxonomies())
                 .map(geotaxes -> geotaxes.stream()
-                    .map(GeographicTaxonomy::getCode)
+                    .map(this::toGeographicTaxonomyDto)
                     .collect(Collectors.toList()))
                 .orElse(null));
         institutionPsp.rea(onboardingData.getInstitutionUpdate().getRea());
@@ -99,4 +100,7 @@ public interface OnboardingMapper {
 
     PaymentServiceProviderRequest toPaymentServiceProviderRequest(PaymentServiceProvider paymentServiceProvider);
     DataProtectionOfficerRequest toDataProtectionOfficerRequest(DataProtectionOfficer dataProtectionOfficer);
+
+    @Mapping(target = "institutionUpdate", source = "institution")
+    OnboardingData toOnboardingData(OnboardingGet onboardingGet);
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
@@ -6,6 +6,7 @@ import it.pagopa.selfcare.onboarding.connector.rest.client.MsOnboardingApiClient
 import it.pagopa.selfcare.onboarding.connector.rest.mapper.OnboardingMapper;
 import it.pagopa.selfcare.onboarding.connector.rest.mapper.OnboardingMapperImpl;
 import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingDefaultRequest;
+import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingGet;
 import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingPaRequest;
 import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingPspRequest;
 import org.junit.jupiter.api.Test;
@@ -16,12 +17,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 
 import static it.pagopa.selfcare.commons.utils.TestUtils.mockInstance;
 import static org.junit.jupiter.api.Assertions.*;
@@ -139,6 +142,21 @@ public class OnboardingMsConnectorImplTest {
         assertDoesNotThrow(executable);
         verify(msOnboardingApiClient, times(1))
                 ._v1OnboardingOnboardingIdPendingGet(onboardingId);
+        verifyNoMoreInteractions(msOnboardingApiClient);
+    }
+
+    @Test
+    void getOnboardingWithUserInfo() {
+        // given
+        final String onboardingId = "onboardingId";
+        when(msOnboardingApiClient._v1OnboardingOnboardingIdWithUserInfoGet(onboardingId))
+                .thenReturn(ResponseEntity.of(Optional.of(new OnboardingGet())));
+        // when
+        final Executable executable = () -> onboardingMsConnector.getOnboardingWithUserInfo(onboardingId);
+        // then
+        assertDoesNotThrow(executable);
+        verify(msOnboardingApiClient, times(1))
+                ._v1OnboardingOnboardingIdWithUserInfoGet(onboardingId);
         verifyNoMoreInteractions(msOnboardingApiClient);
     }
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenService.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.onboarding.core;
 
+import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface TokenService {
@@ -7,6 +8,8 @@ public interface TokenService {
     public void verifyToken(String tokenId);
 
     void verifyOnboarding(String onboardingId);
+
+    OnboardingData getOnboardingWithUserInfo(String onboardingId);
 
     public void completeToken(String tokenId, MultipartFile contract);
 

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenServiceImpl.java
@@ -2,10 +2,15 @@ package it.pagopa.selfcare.onboarding.core;
 
 import it.pagopa.selfcare.onboarding.connector.api.OnboardingMsConnector;
 import it.pagopa.selfcare.onboarding.connector.api.PartyConnector;
+import it.pagopa.selfcare.onboarding.connector.api.UserRegistryConnector;
+import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
+import it.pagopa.selfcare.onboarding.connector.model.user.User;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.EnumSet;
 
 @Slf4j
 @Service
@@ -15,9 +20,18 @@ public class TokenServiceImpl implements TokenService {
 
     private final OnboardingMsConnector onboardingMsConnector;
 
-    public TokenServiceImpl(PartyConnector partyConnector, OnboardingMsConnector onboardingMsConnector) {
+    private final UserRegistryConnector userRegistryConnector;
+
+
+    private static final EnumSet<User.Fields> USER_FIELD_LIST_ENHANCED = EnumSet.of(User.Fields.fiscalCode,
+            User.Fields.name,
+            User.Fields.familyName,
+            User.Fields.workContacts);
+
+    public TokenServiceImpl(PartyConnector partyConnector, OnboardingMsConnector onboardingMsConnector, UserRegistryConnector userRegistryConnector) {
         this.partyConnector = partyConnector;
         this.onboardingMsConnector = onboardingMsConnector;
+        this.userRegistryConnector = userRegistryConnector;
     }
 
     @Override
@@ -38,6 +52,17 @@ public class TokenServiceImpl implements TokenService {
         onboardingMsConnector.onboardingPending(onboardingId);
         log.debug("verifyOnboarding result = success");
         log.trace("verifyOnboarding end");
+    }
+
+    @Override
+    public OnboardingData getOnboardingWithUserInfo(String onboardingId) {
+        log.trace("getOnboardingWithUserInfo start");
+        log.debug("getOnboardingWithUserInfo id = {}", onboardingId);
+        Assert.notNull(onboardingId, "OnboardingId is required");
+        OnboardingData onboardingData = onboardingMsConnector.getOnboardingWithUserInfo(onboardingId);
+        log.debug("getOnboardingWithUserInfo result = success");
+        log.trace("getOnboardingWithUserInfo end");
+        return onboardingData;
     }
 
     @Override

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/TokenServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/TokenServiceImplTest.java
@@ -116,6 +116,17 @@ public class TokenServiceImplTest {
     }
 
     @Test
+    void onboardingWithUserInfo() {
+        //given
+        final String onboardingId = "onboardingId";
+        // when
+        tokenService.getOnboardingWithUserInfo(onboardingId);
+        //then
+        Mockito.verify(onboardingMsConnector, Mockito.times(1))
+                .getOnboardingWithUserInfo(onboardingId);
+    }
+
+    @Test
     void shouldDeleteToken() {
         //given
         String tokenId = "example";

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingRequestResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingRequestResource.java
@@ -1,0 +1,160 @@
+package it.pagopa.selfcare.onboarding.web.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+public class OnboardingRequestResource {
+
+
+    @ApiModelProperty(value = "${swagger.onboarding.model.status}", required = true)
+    @JsonProperty(required = true)
+    private String status;
+
+    @ApiModelProperty(value = "${swagger.onboarding.model.institutionInfo}", required = true)
+    @JsonProperty(required = true)
+    private InstitutionInfo institutionInfo;
+
+    @ApiModelProperty(value = "${swagger.onboarding.model.manager}", required = true)
+    @JsonProperty(required = true)
+    private UserInfo manager;
+
+    @ApiModelProperty(value = "${swagger.onboarding.model.admins}")
+    private List<UserInfo> admins;
+
+
+    @Data
+    @EqualsAndHashCode(of = "id")
+    public static class InstitutionInfo {
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.id}", required = true)
+        @JsonProperty(required = true)
+        private String id;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.name}", required = true)
+        @JsonProperty(required = true)
+        private String name;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.institutionType}", required = true)
+        @JsonProperty(required = true)
+        private InstitutionType institutionType;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.address}", required = true)
+        @JsonProperty(required = true)
+        private String address;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.zipCode}", required = true)
+        @JsonProperty(required = true)
+        private String zipCode;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.city}")
+        private String city;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.country}")
+        private String country;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.county}")
+        private String county;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.digitalAddress}", required = true)
+        @JsonProperty(required = true)
+        private String mailAddress;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCode}", required = true)
+        @JsonProperty(required = true)
+        private String fiscalCode;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.vatNumber}", required = true)
+        @JsonProperty(required = true)
+        private String vatNumber;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.recipientCode}", required = true)
+        @JsonProperty(required = true)
+        private String recipientCode;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.pspData}")
+        private PspData pspData;
+
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.dpoData}")
+        private DpoData dpoData;
+
+        @Data
+        public static class PspData {
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.pspData.businessRegisterNumber}", required = true)
+            @JsonProperty(required = true)
+            private String businessRegisterNumber;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.pspData.legalRegisterName}", required = true)
+            @JsonProperty(required = true)
+            private String legalRegisterName;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.pspData.legalRegisterNumber}", required = true)
+            @JsonProperty(required = true)
+            private String legalRegisterNumber;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.pspData.abiCode}", required = true)
+            @JsonProperty(required = true)
+            private String abiCode;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.pspData.vatNumberGroup}", required = true)
+            @JsonProperty(required = true)
+            private Boolean vatNumberGroup;
+        }
+
+
+        @Data
+        public static class DpoData {
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.dpoData.address}", required = true)
+            @JsonProperty(required = true)
+            @NotBlank
+            private String address;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.dpoData.pec}", required = true)
+            @JsonProperty(required = true)
+            @NotBlank
+            @Email
+            private String pec;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.dpoData.email}", required = true)
+            @JsonProperty(required = true)
+            @NotBlank
+            @Email
+            private String email;
+        }
+    }
+
+    @Data
+    public static class UserInfo {
+
+        @ApiModelProperty(value = "${swagger.onboarding.user.model.id}", required = true)
+        @JsonProperty(required = true)
+        private UUID id;
+
+        @ApiModelProperty(value = "${swagger.onboarding.user.model.name}", required = true)
+        @JsonProperty(required = true)
+        private String name;
+
+        @ApiModelProperty(value = "${swagger.onboarding.user.model.surname}", required = true)
+        @JsonProperty(required = true)
+        private String surname;
+
+        @ApiModelProperty(value = "${swagger.onboarding.user.model.institutionalEmail}", required = true)
+        @JsonProperty(required = true)
+        private String email;
+
+        @ApiModelProperty(value = "${swagger.onboarding.user.model.fiscalCode}", required = true)
+        @JsonProperty(required = true)
+        private String fiscalCode;
+
+    }
+}

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -71,6 +71,10 @@ swagger.onboarding.product.model.id=Product's unique identifier
 swagger.onboarding.product.model.title=Product's title
 swagger.onboarding.product.model.parentId=Product's parent's Id
 swagger.onboarding.product.model.status=Product's status
+swagger.onboarding.model.status=Onboarding request's status
+swagger.onboarding.model.institutionInfo=Institution specific data
+swagger.onboarding.model.manager=Manager specific data. It's required when institutionType is not PT
+swagger.onboarding.model.admins=Administrators specific data
 swagger.onboarding.user.api.validate=Check if requested user data are valid
 swagger.onboarding.user.model.id=User's unique identifier
 swagger.onboarding.user.model.surname=User's surname
@@ -99,3 +103,12 @@ swagger.model.certifiedField.value=Field value
 swagger.tokens.verify=Verify if the token is already consumed
 swagger.tokens.complete=Complete an onboarding request
 swagger.tokens.tokenId=Contract's unique identifier
+swagger.tokens.onboardingId=Onboarding's unique identifier
+
+swagger.tokens.retrieveOnboardingRequest=Service to retrieve a specific onboarding request
+
+
+swagger.onboarding.institutions.model.dpoData=Data Protection Officer (DPO) specific data
+swagger.onboarding.institutions.model.dpoData.address=DPO's address
+swagger.onboarding.institutions.model.dpoData.pec=DPO's PEC
+swagger.onboarding.institutions.model.dpoData.email=DPO's email

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2ControllerTest.java
@@ -1,8 +1,13 @@
 package it.pagopa.selfcare.onboarding.web.controller;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.selfcare.onboarding.connector.model.onboarding.InstitutionUpdate;
+import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
 import it.pagopa.selfcare.onboarding.core.TokenService;
 import it.pagopa.selfcare.onboarding.web.config.WebTestConfig;
+import it.pagopa.selfcare.onboarding.web.model.OnboardingRequestResource;
+import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapperImpl;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -11,6 +16,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -18,12 +24,13 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(value = {TokenV2Controller.class}, excludeAutoConfiguration = SecurityAutoConfiguration.class)
-@ContextConfiguration(classes = {TokenV2Controller.class, WebTestConfig.class})
+@ContextConfiguration(classes = {TokenV2Controller.class, WebTestConfig.class, OnboardingResourceMapperImpl.class})
 public class TokenV2ControllerTest {
 
     @Autowired
@@ -31,6 +38,9 @@ public class TokenV2ControllerTest {
 
     @MockBean
     private TokenService tokenService;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
 
     /**
      * Method under test: {@link TokenV2Controller#complete(String, MultipartFile)}
@@ -65,5 +75,40 @@ public class TokenV2ControllerTest {
         //then
         verify(tokenService, times(1))
                 .verifyOnboarding(onboardingId);
+    }
+
+    /**
+     * Method under test: {@link TokenV2Controller#retrieveOnboardingRequest(String)}
+     */
+    @Test
+    void retrieveOnboardingRequest() throws Exception {
+
+        OnboardingData onboardingData = new OnboardingData();
+        InstitutionUpdate institutionUpdate = new InstitutionUpdate();
+        institutionUpdate.setTaxCode("taxCode");
+        onboardingData.setInstitutionUpdate(institutionUpdate);
+
+        String onboardingId = UUID.randomUUID().toString();
+        when(tokenService.getOnboardingWithUserInfo(onboardingId))
+                .thenReturn(onboardingData);
+
+        //when
+        MvcResult result = mvc.perform(MockMvcRequestBuilders
+                        .get("/v2/tokens/{onboardingId}", onboardingId)
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        OnboardingRequestResource response = objectMapper.readValue(
+                result.getResponse().getContentAsString(),
+                OnboardingRequestResource.class
+        );
+        //then
+
+        assertEquals(institutionUpdate.getTaxCode(), response.getInstitutionInfo().getFiscalCode());
+
+        verify(tokenService, times(1))
+                .getOnboardingWithUserInfo(onboardingId);
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

**New GET Endpoint for Onboarding by ID with User information**: Implemented a new endpoint to retrieve an onboarding record given its ID that added user information such as fiscal code, name and surname. This enhancement allows the front-end to provide onboarding data for administration approving.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The addition of this endpoint is driven by the need for the front-end to effectively verify the data of an onboarding process when an admin must be approve the onboarding. The 'GET onboarding by id' endpoint facilitates access to onboarding records with user information.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.