### PR TITLE
[SELC-3493] feat: Introduce New v2 /reject Endpoint for admin Onboarding Workflow

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2233,6 +2233,81 @@
         } ]
       }
     },
+    "/v2/tokens/{onboardingId}/reject" : {
+      "post" : {
+        "tags" : [ "tokens" ],
+        "summary" : "Service to reject a specific onboarding request",
+        "operationId" : "rejectOnboardingUsingPOST",
+        "parameters" : [ {
+          "name" : "onboardingId",
+          "in" : "path",
+          "description" : "Onboarding's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/v2/tokens/{onboardingId}/verify" : {
       "post" : {
         "tags" : [ "tokens" ],
@@ -3178,6 +3253,10 @@
           "manager" : {
             "description" : "Manager specific data. It's required when institutionType is not PT",
             "$ref" : "#/components/schemas/UserInfo"
+          },
+          "productId" : {
+            "type" : "string",
+            "description" : "Product's unique identifier"
           },
           "status" : {
             "type" : "string",

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
@@ -12,6 +12,8 @@ public interface OnboardingMsConnector {
 
     void approveOnboarding(String onboardingId);
 
+    void rejectOnboarding(String onboardingId);
+
     OnboardingData getOnboarding(String onboardingId);
 
     OnboardingData getOnboardingWithUserInfo(String onboardingId);

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -223,38 +223,7 @@
     "/v1/onboarding/{onboardingId}/approve" : {
       "put" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform approve operation of an onboarding request receiving onboarding id.Function triggers async activities related to onboarding based on institution type. ",
-        "parameters" : [ {
-          "name" : "onboardingId",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : { }
-            }
-          },
-          "403" : {
-            "description" : "Not Allowed"
-          },
-          "401" : {
-            "description" : "Not Authorized"
-          }
-        },
-        "security" : [ {
-          "SecurityScheme" : [ ]
-        } ]
-      }
-    },
-    "/v1/onboarding/{onboardingId}/approve/completion" : {
-      "put" : {
-        "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform approve operation of an onboarding request receiving onboarding id.It triggers async activities related to complete onboarding workflow after approving ",
+        "summary" : "Perform approve operation of an onboarding request receiving onboarding id.Function triggers async activities related to onboarding based on institution type or completing onboarding. ",
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",
@@ -328,36 +297,6 @@
         } ]
       }
     },
-    "/v1/onboarding/{onboardingId}/delete" : {
-      "put" : {
-        "tags" : [ "Onboarding Controller" ],
-        "parameters" : [ {
-          "name" : "onboardingId",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : { }
-            }
-          },
-          "403" : {
-            "description" : "Not Allowed"
-          },
-          "401" : {
-            "description" : "Not Authorized"
-          }
-        },
-        "security" : [ {
-          "SecurityScheme" : [ ]
-        } ]
-      }
-    },
     "/v1/onboarding/{onboardingId}/pending" : {
       "get" : {
         "tags" : [ "Onboarding Controller" ],
@@ -379,6 +318,37 @@
                   "$ref" : "#/components/schemas/OnboardingGet"
                 }
               }
+            }
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/v1/onboarding/{onboardingId}/reject" : {
+      "put" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "Perform reject operation of an onboarding request receiving onboarding id.Function change status to REJECT for an onboarding request that is not COMPLETED. ",
+        "parameters" : [ {
+          "name" : "onboardingId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : { }
             }
           },
           "403" : {

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
@@ -52,6 +52,11 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
     }
 
     @Override
+    public void rejectOnboarding(String onboardingId) {
+        msOnboardingApiClient._v1OnboardingOnboardingIdRejectPut(onboardingId);
+    }
+
+    @Override
     public OnboardingData getOnboarding(String onboardingId) {
         OnboardingGet onboardingGet = msOnboardingApiClient._v1OnboardingOnboardingIdGet(onboardingId).getBody();
         return onboardingMapper.toOnboardingData(onboardingGet);

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
@@ -172,4 +172,17 @@ public class OnboardingMsConnectorImplTest {
                 ._v1OnboardingOnboardingIdApprovePut(onboardingId);
         verifyNoMoreInteractions(msOnboardingApiClient);
     }
+
+    @Test
+    void rejectOnboarding() {
+        // given
+        final String onboardingId = "onboardingId";
+        // when
+        final Executable executable = () -> onboardingMsConnector.rejectOnboarding(onboardingId);
+        // then
+        assertDoesNotThrow(executable);
+        verify(msOnboardingApiClient, times(1))
+                ._v1OnboardingOnboardingIdRejectPut(onboardingId);
+        verifyNoMoreInteractions(msOnboardingApiClient);
+    }
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenService.java
@@ -11,6 +11,8 @@ public interface TokenService {
 
     void approveOnboarding(String onboardingId);
 
+    void rejectOnboarding(String onboardingId);
+
     OnboardingData getOnboardingWithUserInfo(String onboardingId);
 
     public void completeToken(String tokenId, MultipartFile contract);

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenServiceImpl.java
@@ -65,6 +65,16 @@ public class TokenServiceImpl implements TokenService {
     }
 
     @Override
+    public void rejectOnboarding(String onboardingId) {
+        log.trace("rejectOnboarding start");
+        log.debug("rejectOnboarding id = {}", onboardingId);
+        Assert.notNull(onboardingId, "OnboardingId is required");
+        onboardingMsConnector.rejectOnboarding(onboardingId);
+        log.debug("rejectOnboarding result = success");
+        log.trace("rejectOnboarding end");
+    }
+
+    @Override
     public OnboardingData getOnboardingWithUserInfo(String onboardingId) {
         log.trace("getOnboardingWithUserInfo start");
         log.debug("getOnboardingWithUserInfo id = {}", onboardingId);

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/TokenServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/TokenServiceImplTest.java
@@ -149,4 +149,16 @@ public class TokenServiceImplTest {
         Mockito.verify(onboardingMsConnector, Mockito.times(1))
                 .approveOnboarding(onboardingId);
     }
+
+    @Test
+    void rejectOnboarding() {
+        //given
+        String onboardingId = "example";
+        doNothing().when(onboardingMsConnector).rejectOnboarding(onboardingId);
+        // when
+        tokenService.rejectOnboarding(onboardingId);
+        //then
+        Mockito.verify(onboardingMsConnector, Mockito.times(1))
+                .rejectOnboarding(onboardingId);
+    }
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -94,8 +94,6 @@ public class TokenV2Controller {
         return result;
     }
 
-
-
     /**
      * The function is used to approve the onboarding by admin.
      * It takes in a String onboarding id.
@@ -115,4 +113,26 @@ public class TokenV2Controller {
         tokenService.approveOnboarding(onboardingId);
     }
 
+
+
+
+
+    /**
+     * The function is used to reject the onboarding by admin.
+     * It takes in a String onboarding id.
+     *
+     * @param onboardingId onboardingId
+     * * Code: 200, Message: successful operation, DataType: TokenId
+     * * Code: 400, Message: Invalid ID supplied, DataType: Problem
+     * * Code: 404, Message: Token not found, DataType: Problem
+     * * Code: 409, Message: Token already consumed, DataType: Problem
+     */
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "${swagger.tokens.rejectOnboardingRequest}")
+    @PostMapping("/{onboardingId}/reject")
+    public void rejectOnboarding(@ApiParam("${swagger.tokens.onboardingId}")
+                                  @PathVariable("onboardingId") String onboardingId) {
+        log.debug("reject onboarding identified with {}", onboardingId);
+        tokenService.rejectOnboarding(onboardingId);
+    }
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingRequestResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingRequestResource.java
@@ -30,6 +30,8 @@ public class OnboardingRequestResource {
     @ApiModelProperty(value = "${swagger.onboarding.model.admins}")
     private List<UserInfo> admins;
 
+    @ApiModelProperty(value = "${swagger.dashboard.onboarding-request.model.productId}")
+    private String productId;
 
     @Data
     @EqualsAndHashCode(of = "id")

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingRequestResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingRequestResource.java
@@ -30,7 +30,7 @@ public class OnboardingRequestResource {
     @ApiModelProperty(value = "${swagger.onboarding.model.admins}")
     private List<UserInfo> admins;
 
-    @ApiModelProperty(value = "${swagger.dashboard.onboarding-request.model.productId}")
+    @ApiModelProperty(value = "${swagger.onboarding.product.model.id}")
     private String productId;
 
     @Data

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2ControllerTest.java
@@ -133,4 +133,26 @@ public class TokenV2ControllerTest {
         verify(tokenService, times(1))
                 .approveOnboarding(onboardingId);
     }
+
+    /**
+     * Method under test: {@link TokenV2Controller#rejectOnboarding(String)}
+     */
+    @Test
+    void rejectOnboardingRequest() throws Exception {
+
+        String onboardingId = UUID.randomUUID().toString();
+        doNothing().when(tokenService).rejectOnboarding(onboardingId);
+
+        //when
+        mvc.perform(MockMvcRequestBuilders
+                        .post("/v2/tokens/{onboardingId}/reject", onboardingId)
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andReturn();
+        //then
+
+        verify(tokenService, times(1))
+                .rejectOnboarding(onboardingId);
+    }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* Added a new endpoint, version v2 /reject, which is designed to process reject for certain types of institutions during the onboarding process.
* This endpoint triggers the new onboarding service

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This change is necessary to streamline the onboarding process for specific types of institutions that require administrative rejection. The existing onboarding process redirect to old onboarding service.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.