### PR TITLE
[SELC-3790] fix: change field name isIpa and isAgentOfPublicService

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2474,7 +2474,9 @@
         "type" : "object",
         "properties" : {
           "agentOfPublicService" : {
-            "type" : "boolean"
+            "type" : "boolean",
+            "description" : "The institution is an agent of a public service",
+            "example" : false
           },
           "agentOfPublicServiceNote" : {
             "type" : "string",
@@ -2495,7 +2497,9 @@
             "description" : "establishedByRegulatoryProvision Note"
           },
           "ipa" : {
-            "type" : "boolean"
+            "type" : "boolean",
+            "description" : "The institution is registered on IPA",
+            "example" : false
           },
           "ipaCode" : {
             "type" : "string",

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/AdditionalInformations.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/AdditionalInformations.java
@@ -6,11 +6,11 @@ public class AdditionalInformations {
 
     private boolean belongRegulatedMarket;
     private String regulatedMarketNote;
-    private boolean isIpa;
+    private boolean ipa;
     private String ipaCode;
     private boolean establishedByRegulatoryProvision;
     private String establishedByRegulatoryProvisionNote;
-    private boolean isAgentOfPublicService;
+    private boolean agentOfPublicService;
     private String agentOfPublicServiceNote;
     private String otherNote;
 

--- a/connector/rest/src/test/resources/stubs/party-process/mappings/getUserInstitutionRelationships_fullyValued.json
+++ b/connector/rest/src/test/resources/stubs/party-process/mappings/getUserInstitutionRelationships_fullyValued.json
@@ -35,11 +35,11 @@
           "additionalInformations" : {
             "belongRegulatedMarket" : true,
             "regulatedMarketNote" :  "string",
-            "isIpa" : true,
+            "ipa" : true,
             "ipaCode" : "string",
             "establishedByRegulatoryProvision" : true,
             "establishedByRegulatoryProvisionNote" : "string",
-            "isAgentOfPublicService" : true,
+            "agentOfPublicService" : true,
             "agentOfPublicServiceNote" : "string",
             "otherNote" : "string"
           },

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/AdditionalInformationsDto.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/AdditionalInformationsDto.java
@@ -12,8 +12,8 @@ public class AdditionalInformationsDto {
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.assistance.regulatedMarketNote}")
     private String regulatedMarketNote;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.assistance.isIpa}")
-    private boolean isIpa;
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.assistance.ipa}")
+    private boolean ipa;
 
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.assistance.ipaCode}")
     private String ipaCode;
@@ -24,8 +24,8 @@ public class AdditionalInformationsDto {
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.assistance.establishedByRegulatoryProvisionNote}")
     private String establishedByRegulatoryProvisionNote;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.assistance.isAgentOfPublicService}")
-    private boolean isAgentOfPublicService;
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.assistance.agentOfPublicService}")
+    private boolean agentOfPublicService;
 
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.assistance.agentOfPublicServiceNote}")
     private String agentOfPublicServiceNote;

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -117,11 +117,11 @@ swagger.onboarding.institutions.model.dpoData.email=DPO's email
 swagger.onboarding.institutions.model.additionalInformations=GSP institution's additional informations
 swagger.onboarding.institutions.model.assistance.belongRegulatedMarket= The institution belongs to a regulated market
 swagger.onboarding.institutions.model.assistance.regulatedMarketNote=regulatedMarket Note
-swagger.onboarding.institutions.model.assistance.isIpa=The institution is registered on IPA
+swagger.onboarding.institutions.model.assistance.ipa=The institution is registered on IPA
 swagger.onboarding.institutions.model.assistance.ipaCode=IPA code
 swagger.onboarding.institutions.model.assistance.establishedByRegulatoryProvision=The institution is a company established by a regulatory provision
 swagger.onboarding.institutions.model.assistance.establishedByRegulatoryProvisionNote=establishedByRegulatoryProvision Note
-swagger.onboarding.institutions.model.assistance.isAgentOfPublicService=The institution is an agent of a public service
+swagger.onboarding.institutions.model.assistance.agentOfPublicService=The institution is an agent of a public service
 swagger.onboarding.institutions.model.assistance.agentOfPublicServiceNote=agentOfPublicService Note
 swagger.onboarding.institutions.model.assistance.otherNote=Other note
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- change isAgentOfPublicService and isIpa to agentOfPublicService and ipa 

<!--- Describe your changes in detail -->

#### Motivation and Context
The mentioned fields names ("isIpa" and "isAgentOfPublicService") were not reconized.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.