### PR TITLE
feat: added new AdditionalInformations Object for API V2

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2469,6 +2469,52 @@
   },
   "components" : {
     "schemas" : {
+      "AdditionalInformations" : {
+        "title" : "AdditionalInformations",
+        "type" : "object",
+        "properties" : {
+          "agentOfPublicService" : {
+            "type" : "boolean",
+            "description" : "The institution is an agent of a public service",
+            "example" : false
+          },
+          "agentOfPublicServiceNote" : {
+            "type" : "string",
+            "description" : "agentOfPublicService Note"
+          },
+          "belongRegulatedMarket" : {
+            "type" : "boolean",
+            "description" : "The institution belongs to a regulated market",
+            "example" : false
+          },
+          "establishedByRegulatoryProvision" : {
+            "type" : "boolean",
+            "description" : "The institution is a company established by a regulatory provision",
+            "example" : false
+          },
+          "establishedByRegulatoryProvisionNote" : {
+            "type" : "string",
+            "description" : "establishedByRegulatoryProvision Note"
+          },
+          "ipa" : {
+            "type" : "boolean",
+            "description" : "The institution is registered on IPA",
+            "example" : false
+          },
+          "ipaCode" : {
+            "type" : "string",
+            "description" : "IPA code"
+          },
+          "otherNote" : {
+            "type" : "string",
+            "description" : "Other note"
+          },
+          "regulatedMarketNote" : {
+            "type" : "string",
+            "description" : "regulatedMarket Note"
+          }
+        }
+      },
       "AdditionalInformationsDto" : {
         "title" : "AdditionalInformationsDto",
         "type" : "object",
@@ -2889,6 +2935,10 @@
         "required" : [ "address", "fiscalCode", "id", "institutionType", "mailAddress", "name", "recipientCode", "vatNumber", "zipCode" ],
         "type" : "object",
         "properties" : {
+          "additionalInformations" : {
+            "description" : "GSP institution's additional informations",
+            "$ref" : "#/components/schemas/AdditionalInformations"
+          },
           "address" : {
             "type" : "string",
             "description" : "Institution's physical address"

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -113,6 +113,42 @@
         } ]
       }
     },
+    "/v1/onboarding/completion" : {
+      "post" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "Perform onboarding as /onboarding but completing the onboarding request to COMPLETED phase.",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OnboardingDefaultRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OnboardingResponse"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
     "/v1/onboarding/pa" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
@@ -149,10 +185,82 @@
         } ]
       }
     },
+    "/v1/onboarding/pa/completion" : {
+      "post" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "Perform onboarding as /onboarding/pa but completing the onboarding request to COMPLETED phase.",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OnboardingPaRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OnboardingResponse"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
     "/v1/onboarding/psp" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
         "summary" : "Perform onboarding request for PSP institution type.Users data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding that consist of sending mail to Selfcare admin for approve request.",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OnboardingPspRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OnboardingResponse"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/v1/onboarding/psp/completion" : {
+      "post" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "Perform onboarding as /onboarding/psp but completing the onboarding request to COMPLETED phase.",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -401,6 +509,70 @@
   },
   "components" : {
     "schemas" : {
+      "AdditionalInformationsRequest" : {
+        "type" : "object",
+        "properties" : {
+          "belongRegulatedMarket" : {
+            "type" : "boolean"
+          },
+          "regulatedMarketNote" : {
+            "type" : "string"
+          },
+          "ipa" : {
+            "type" : "boolean"
+          },
+          "ipaCode" : {
+            "type" : "string"
+          },
+          "establishedByRegulatoryProvision" : {
+            "type" : "boolean"
+          },
+          "establishedByRegulatoryProvisionNote" : {
+            "type" : "string"
+          },
+          "agentOfPublicService" : {
+            "type" : "boolean"
+          },
+          "agentOfPublicServiceNote" : {
+            "type" : "string"
+          },
+          "otherNote" : {
+            "type" : "string"
+          }
+        }
+      },
+      "AdditionalInformationsResponse" : {
+        "type" : "object",
+        "properties" : {
+          "belongRegulatedMarket" : {
+            "type" : "boolean"
+          },
+          "regulatedMarketNote" : {
+            "type" : "string"
+          },
+          "ipa" : {
+            "type" : "boolean"
+          },
+          "ipaCode" : {
+            "type" : "string"
+          },
+          "establishedByRegulatoryProvision" : {
+            "type" : "boolean"
+          },
+          "establishedByRegulatoryProvisionNote" : {
+            "type" : "string"
+          },
+          "agentOfPublicService" : {
+            "type" : "boolean"
+          },
+          "agentOfPublicServiceNote" : {
+            "type" : "string"
+          },
+          "otherNote" : {
+            "type" : "string"
+          }
+        }
+      },
       "BillingPaRequest" : {
         "required" : [ "vatNumber", "recipientCode" ],
         "type" : "object",
@@ -744,6 +916,9 @@
           },
           "billing" : {
             "$ref" : "#/components/schemas/BillingRequest"
+          },
+          "additionalInformations" : {
+            "$ref" : "#/components/schemas/AdditionalInformationsRequest"
           }
         }
       },
@@ -776,6 +951,9 @@
           },
           "signContract" : {
             "type" : "boolean"
+          },
+          "additionalInformations" : {
+            "$ref" : "#/components/schemas/AdditionalInformationsResponse"
           },
           "status" : {
             "type" : "string"

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/OnboardingMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/OnboardingMapper.java
@@ -22,6 +22,7 @@ public interface OnboardingMapper {
     @Mapping(target = "institution", source = ".", qualifiedByName = "toInstitutionPsp")
     OnboardingPspRequest toOnboardingPspRequest(OnboardingData onboardingData);
     @Mapping(target = "institution", source = ".", qualifiedByName = "toInstitutionBase")
+    @Mapping(target = "additionalInformations", source = "institutionUpdate.additionalInformations")
     OnboardingDefaultRequest toOnboardingDefaultRequest(OnboardingData onboardingData);
 
     GeographicTaxonomyDto toGeographicTaxonomyDto(GeographicTaxonomy geographicTaxonomy);
@@ -102,5 +103,6 @@ public interface OnboardingMapper {
     DataProtectionOfficerRequest toDataProtectionOfficerRequest(DataProtectionOfficer dataProtectionOfficer);
 
     @Mapping(target = "institutionUpdate", source = "institution")
+    @Mapping(target = "institutionUpdate.additionalInformations", source = "additionalInformations")
     OnboardingData toOnboardingData(OnboardingGet onboardingGet);
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingRequestResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingRequestResource.java
@@ -88,6 +88,39 @@ public class OnboardingRequestResource {
         @ApiModelProperty(value = "${swagger.onboarding.institutions.model.dpoData}")
         private DpoData dpoData;
 
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.additionalInformations}")
+        private AdditionalInformations additionalInformations;
+
+        @Data
+        public static class AdditionalInformations{
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.additionalInformations.belongRegulatedMarket}")
+            private boolean belongRegulatedMarket;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.additionalInformations.regulatedMarketNote}")
+            private String regulatedMarketNote;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.additionalInformations.ipa}")
+            private boolean ipa;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.additionalInformations.ipaCode}")
+            private String ipaCode;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.additionalInformations.establishedByRegulatoryProvision}")
+            private boolean establishedByRegulatoryProvision;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.additionalInformations.establishedByRegulatoryProvisionNote}")
+            private String establishedByRegulatoryProvisionNote;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.additionalInformations.agentOfPublicService}")
+            private boolean agentOfPublicService;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.additionalInformations.agentOfPublicServiceNote}")
+            private String agentOfPublicServiceNote;
+
+            @ApiModelProperty(value = "${swagger.onboarding.institutions.model.additionalInformations.otherNote}")
+            private String otherNote;
+        }
+
         @Data
         public static class PspData {
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/OnboardingResourceMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/OnboardingResourceMapper.java
@@ -59,6 +59,7 @@ public interface OnboardingResourceMapper {
 
     @Mapping(source = "users", target = "manager", qualifiedByName = "toManager")
     @Mapping(source = "users", target = "admins", qualifiedByName = "toAdmin")
+    @Mapping(source = "institutionUpdate.additionalInformations", target = "institutionInfo.additionalInformations")
     OnboardingRequestResource toOnboardingRequestResource(OnboardingData onboardingData);
 
     @Mapping(source = "taxCode", target = "fiscalCode")

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -125,3 +125,14 @@ swagger.onboarding.institutions.model.assistance.agentOfPublicService=The instit
 swagger.onboarding.institutions.model.assistance.agentOfPublicServiceNote=agentOfPublicService Note
 swagger.onboarding.institutions.model.assistance.otherNote=Other note
 
+swagger.onboarding.institutions.model.additionalInformations.belongRegulatedMarket=The institution belongs to a regulated market
+swagger.onboarding.institutions.model.additionalInformations.regulatedMarketNote=regulatedMarket Note
+swagger.onboarding.institutions.model.additionalInformations.ipa=The institution is registered on IPA
+swagger.onboarding.institutions.model.additionalInformations.ipaCode=IPA code
+swagger.onboarding.institutions.model.additionalInformations.establishedByRegulatoryProvision=The institution is a company established by a regulatory provision
+swagger.onboarding.institutions.model.additionalInformations.establishedByRegulatoryProvisionNote=establishedByRegulatoryProvision Note
+swagger.onboarding.institutions.model.additionalInformations.agentOfPublicService=The institution is an agent of a public service
+swagger.onboarding.institutions.model.additionalInformations.agentOfPublicServiceNote=agentOfPublicService Note
+swagger.onboarding.institutions.model.additionalInformations.otherNote=Other note
+
+


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added new AdditionalInformations Object within the various objects during the onboarding phase for API V2

#### Motivation and Context

The Additional Information is used by the PagoPA administrator when he has to refuse or approve a membership request; in short, they facilitate this operation for the administrator himself, having more information.
Having made the change in the onboarding microservice, this new object has also been added for the V2 APIs for creating onboarding and retrieving data for the PagoPA administrator

#### How Has This Been Tested?

The new V2 APIs have been invoked locally for the creation of onboarding and the retrieval of information during the rejection or approval phase of the request

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.