### PR TITLE
feat: [SELC-4354] add API getContract to download an onboarding request's contract

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1617,8 +1617,7 @@
             "content" : {
               "application/octet-stream" : {
                 "schema" : {
-                  "type" : "string",
-                  "format" : "byte"
+                  "$ref" : "#/components/schemas/Resource"
                 }
               }
             }
@@ -2333,6 +2332,10 @@
           }
         }
       },
+      "InputStream" : {
+        "title" : "InputStream",
+        "type" : "object"
+      },
       "InstitutionData" : {
         "title" : "InstitutionData",
         "type" : "object",
@@ -2875,6 +2878,39 @@
           "reason" : {
             "type" : "string",
             "description" : "Rejection reason of an onboarding request"
+          }
+        }
+      },
+      "Resource" : {
+        "title" : "Resource",
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "file" : {
+            "type" : "string",
+            "format" : "binary"
+          },
+          "filename" : {
+            "type" : "string"
+          },
+          "inputStream" : {
+            "$ref" : "#/components/schemas/InputStream"
+          },
+          "open" : {
+            "type" : "boolean"
+          },
+          "readable" : {
+            "type" : "boolean"
+          },
+          "uri" : {
+            "type" : "string",
+            "format" : "uri"
+          },
+          "url" : {
+            "type" : "string",
+            "format" : "url"
           }
         }
       },

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1595,6 +1595,80 @@
         } ]
       }
     },
+    "/v2/tokens/{onboardingId}/contract" : {
+      "get" : {
+        "tags" : [ "tokens" ],
+        "summary" : "getContract",
+        "description" : "Service to download a specific onboarding contract",
+        "operationId" : "getContractUsingGET",
+        "parameters" : [ {
+          "name" : "onboardingId",
+          "in" : "path",
+          "description" : "Onboarding's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/octet-stream" : {
+                "schema" : {
+                  "type" : "string",
+                  "format" : "byte"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/v2/tokens/{onboardingId}/reject" : {
       "post" : {
         "tags" : [ "tokens" ],

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1617,7 +1617,8 @@
             "content" : {
               "application/octet-stream" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/Resource"
+                  "type" : "string",
+                  "format" : "byte"
                 }
               }
             }
@@ -2332,10 +2333,6 @@
           }
         }
       },
-      "InputStream" : {
-        "title" : "InputStream",
-        "type" : "object"
-      },
       "InstitutionData" : {
         "title" : "InstitutionData",
         "type" : "object",
@@ -2878,39 +2875,6 @@
           "reason" : {
             "type" : "string",
             "description" : "Rejection reason of an onboarding request"
-          }
-        }
-      },
-      "Resource" : {
-        "title" : "Resource",
-        "type" : "object",
-        "properties" : {
-          "description" : {
-            "type" : "string"
-          },
-          "file" : {
-            "type" : "string",
-            "format" : "binary"
-          },
-          "filename" : {
-            "type" : "string"
-          },
-          "inputStream" : {
-            "$ref" : "#/components/schemas/InputStream"
-          },
-          "open" : {
-            "type" : "boolean"
-          },
-          "readable" : {
-            "type" : "boolean"
-          },
-          "uri" : {
-            "type" : "string",
-            "format" : "uri"
-          },
-          "url" : {
-            "type" : "string",
-            "format" : "url"
           }
         }
       },

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.onboarding.connector.api;
 
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
+import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface OnboardingMsConnector {
@@ -19,4 +20,6 @@ public interface OnboardingMsConnector {
     OnboardingData getOnboarding(String onboardingId);
 
     OnboardingData getOnboardingWithUserInfo(String onboardingId);
+
+    Resource getContract(String onboardingId);
 }

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -1306,7 +1306,6 @@
             "$ref" : "#/components/schemas/Origin"
           },
           "digitalAddress" : {
-            "pattern" : "\\S",
             "type" : "string"
           }
         }

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -67,11 +67,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -101,11 +101,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -137,11 +137,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -173,11 +173,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -209,11 +209,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -245,11 +245,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -280,11 +280,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -316,11 +316,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -352,11 +352,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -387,11 +387,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -418,11 +418,11 @@
               "application/json" : { }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -465,11 +465,11 @@
               "application/json" : { }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -512,11 +512,11 @@
               "application/json" : { }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -547,11 +547,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -587,11 +587,11 @@
               "application/json" : { }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -622,11 +622,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -659,11 +659,47 @@
               }
             }
           },
+          "403" : {
+            "description" : "Not Allowed"
+          },
           "401" : {
             "description" : "Not Authorized"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/v1/tokens/{onboardingId}/contract" : {
+      "get" : {
+        "tags" : [ "Token Controller" ],
+        "summary" : "Retrieve contract not signed for a given onboarding",
+        "parameters" : [ {
+          "name" : "onboardingId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/octet-stream" : {
+                "schema" : {
+                  "format" : "binary",
+                  "type" : "string"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -1270,6 +1306,7 @@
             "$ref" : "#/components/schemas/Origin"
           },
           "digitalAddress" : {
+            "pattern" : "\\S",
             "type" : "string"
           }
         }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
@@ -4,10 +4,12 @@ import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.onboarding.connector.api.OnboardingMsConnector;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
 import it.pagopa.selfcare.onboarding.connector.rest.client.MsOnboardingApiClient;
+import it.pagopa.selfcare.onboarding.connector.rest.client.MsOnboardingTokenApiClient;
 import it.pagopa.selfcare.onboarding.connector.rest.mapper.OnboardingMapper;
 import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.OnboardingGet;
 import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.ReasonRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -19,10 +21,13 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
 
     private final MsOnboardingApiClient msOnboardingApiClient;
 
+    private final MsOnboardingTokenApiClient msOnboardingTokenApiClient;
+
     private final OnboardingMapper onboardingMapper;
 
-    public OnboardingMsConnectorImpl(MsOnboardingApiClient msOnboardingApiClient, OnboardingMapper onboardingMapper) {
+    public OnboardingMsConnectorImpl(MsOnboardingApiClient msOnboardingApiClient, MsOnboardingTokenApiClient msOnboardingTokenApiClient, OnboardingMapper onboardingMapper) {
         this.msOnboardingApiClient = msOnboardingApiClient;
+        this.msOnboardingTokenApiClient = msOnboardingTokenApiClient;
         this.onboardingMapper = onboardingMapper;
     }
 
@@ -75,5 +80,10 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
     public OnboardingData getOnboardingWithUserInfo(String onboardingId) {
         OnboardingGet onboardingGet = msOnboardingApiClient._v1OnboardingOnboardingIdWithUserInfoGet(onboardingId).getBody();
         return onboardingMapper.toOnboardingData(onboardingGet);
+    }
+
+    @Override
+    public Resource getContract(String onboardingId) {
+        return msOnboardingTokenApiClient._v1TokensOnboardingIdContractGet(onboardingId).getBody();
     }
 }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/client/MsOnboardingTokenApiClient.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/client/MsOnboardingTokenApiClient.java
@@ -1,0 +1,9 @@
+package it.pagopa.selfcare.onboarding.connector.rest.client;
+
+import it.pagopa.selfcare.onboarding.generated.openapi.v1.api.TokenControllerApi;
+import org.springframework.cloud.openfeign.FeignClient;
+
+
+@FeignClient(name = "${rest-client.ms-onboarding-token-api.serviceCode}", url = "${rest-client.ms-onboarding.base-url}")
+public interface MsOnboardingTokenApiClient extends TokenControllerApi {
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/config/MsOnboardingApiClientConfig.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/config/MsOnboardingApiClientConfig.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.onboarding.connector.rest.config;
 
 import it.pagopa.selfcare.commons.connector.rest.config.RestClientBaseConfig;
 import it.pagopa.selfcare.onboarding.connector.rest.client.MsOnboardingApiClient;
+import it.pagopa.selfcare.onboarding.connector.rest.client.MsOnboardingTokenApiClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -9,7 +10,7 @@ import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @Import(RestClientBaseConfig.class)
-@EnableFeignClients(clients = {MsOnboardingApiClient.class})
+@EnableFeignClients(clients = {MsOnboardingApiClient.class, MsOnboardingTokenApiClient.class})
 @PropertySource("classpath:config/ms-onboarding-rest-client.properties")
 public class MsOnboardingApiClientConfig {
 }

--- a/connector/rest/src/main/resources/config/ms-onboarding-rest-client.properties
+++ b/connector/rest/src/main/resources/config/ms-onboarding-rest-client.properties
@@ -1,6 +1,7 @@
 
 rest-client.ms-onboarding.base-url=${MS_ONBOARDING_URL:http://10.1.1.250:80/ms-onboarding/v1}
 rest-client.ms-onboarding-api.serviceCode=ms-onboarding-api
+rest-client.ms-onboarding-token-api.serviceCode=ms-onboarding-token-api
 feign.client.config.ms-onboarding-api.requestInterceptors[0]=it.pagopa.selfcare.commons.connector.rest.interceptor.AuthorizationHeaderInterceptor
 feign.client.config.ms-onboarding-api.errorDecoder=it.pagopa.selfcare.onboarding.connector.rest.decoder.FeignErrorDecoder
 feign.client.config.ms-onboarding-api.readTimeout=${USERVICE_PARTY_PROCESS_REST_CLIENT_READ_TIMEOUT:${REST_CLIENT_READ_TIMEOUT:5000}}

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
@@ -3,17 +3,16 @@ package it.pagopa.selfcare.onboarding.connector;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.*;
 import it.pagopa.selfcare.onboarding.connector.rest.client.MsOnboardingApiClient;
+import it.pagopa.selfcare.onboarding.connector.rest.client.MsOnboardingTokenApiClient;
 import it.pagopa.selfcare.onboarding.connector.rest.mapper.OnboardingMapper;
 import it.pagopa.selfcare.onboarding.connector.rest.mapper.OnboardingMapperImpl;
 import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
 
@@ -34,6 +33,9 @@ public class OnboardingMsConnectorImplTest {
     private OnboardingMsConnectorImpl onboardingMsConnector;
     @Mock
     private MsOnboardingApiClient msOnboardingApiClient;
+
+    @Mock
+    private MsOnboardingTokenApiClient msOnboardingTokenApiClient;
 
     @Spy
     private OnboardingMapper onboardingMapper = new OnboardingMapperImpl();
@@ -210,5 +212,21 @@ public class OnboardingMsConnectorImplTest {
         verify(msOnboardingApiClient, times(1))
                 ._v1OnboardingOnboardingIdRejectPut(onboardingId, reasonDto);
         verifyNoMoreInteractions(msOnboardingApiClient);
+    }
+
+    @Test
+    void getContract() {
+        // given
+        final String onboardingId = "onboardingId";
+        Resource resource = Mockito.mock(Resource.class);
+        when(msOnboardingTokenApiClient._v1TokensOnboardingIdContractGet(onboardingId))
+                .thenReturn(ResponseEntity.of(Optional.of(resource)));
+        // when
+        final Executable executable = () -> onboardingMsConnector.getContract(onboardingId);
+        // then
+        assertDoesNotThrow(executable);
+        verify(msOnboardingTokenApiClient, times(1))
+                ._v1TokensOnboardingIdContractGet(onboardingId);
+        verifyNoMoreInteractions(msOnboardingTokenApiClient);
     }
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenService.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.onboarding.core;
 
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
+import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface TokenService {
@@ -13,4 +14,6 @@ public interface TokenService {
     OnboardingData getOnboardingWithUserInfo(String onboardingId);
 
     void completeTokenV2(String onboardingId, MultipartFile contract);
+
+    Resource getContract(String onboardingId);
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/TokenServiceImpl.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.onboarding.core;
 import it.pagopa.selfcare.onboarding.connector.api.OnboardingMsConnector;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import org.springframework.web.multipart.MultipartFile;
@@ -69,5 +70,16 @@ public class TokenServiceImpl implements TokenService {
         onboardingMsConnector.onboardingTokenComplete(onboardingId, contract);
         log.debug("completeTokenAsync result = success");
         log.trace("completeTokenAsync end");
+    }
+
+    @Override
+    public Resource getContract(String onboardingId) {
+        log.trace("getContract start");
+        log.debug("getContract id = {}", onboardingId);
+        Assert.notNull(onboardingId, "TokenId is required");
+        Resource resource = onboardingMsConnector.getContract(onboardingId);
+        log.debug("getContract result = success");
+        log.trace("getContract end");
+        return resource;
     }
 }

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/TokenServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/TokenServiceImplTest.java
@@ -102,4 +102,15 @@ public class TokenServiceImplTest {
         Mockito.verify(onboardingMsConnector, Mockito.times(1))
                 .rejectOnboarding(onboardingId, reason);
     }
+
+    @Test
+    void getContract() {
+        //given
+        final String onboardingId = "onboardingId";
+        // when
+        tokenService.getContract(onboardingId);
+        //then
+        Mockito.verify(onboardingMsConnector, Mockito.times(1))
+                .getContract(onboardingId);
+    }
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -20,8 +20,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-
 @Slf4j
 @RestController
 @RequestMapping(value = "/v2/tokens", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -166,16 +164,15 @@ public class TokenV2Controller {
     @GetMapping(value = "/{onboardingId}/contract", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.tokens.getContract}")
-    public ResponseEntity<byte[]> getContract(@ApiParam("${swagger.tokens.onboardingId}")
+    public ResponseEntity<Resource> getContract(@ApiParam("${swagger.tokens.onboardingId}")
                                               @PathVariable("onboardingId")
-                                              String onboardingId) throws IOException {
+                                              String onboardingId){
         log.trace("getContract start");
         log.debug("getContract onboardingId = {}", onboardingId);
         Resource contract = tokenService.getContract(onboardingId);
-        byte[] bytes = contract.getInputStream().readAllBytes();
         log.trace("getContract end");
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" +contract.getFilename())
-                .body(bytes);
+                .body(contract);
     }
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -12,11 +12,15 @@ import it.pagopa.selfcare.onboarding.web.model.OnboardingVerify;
 import it.pagopa.selfcare.onboarding.web.model.ReasonForRejectDto;
 import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Slf4j
 @RestController
@@ -156,5 +160,22 @@ public class TokenV2Controller {
         log.debug("delete Token tokenId = {}", onboardingId);
         tokenService.rejectOnboarding(onboardingId, null);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+
+    @GetMapping(value = "/{onboardingId}/contract", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "", notes = "${swagger.tokens.getContract}")
+    public ResponseEntity<byte[]> getContract(@ApiParam("${swagger.tokens.onboardingId}")
+                                              @PathVariable("onboardingId")
+                                              String onboardingId) throws IOException {
+        log.trace("getContract start");
+        log.debug("getContract onboardingId = {}", onboardingId);
+        Resource contract = tokenService.getContract(onboardingId);
+        byte[] bytes = contract.getInputStream().readAllBytes();
+        log.trace("getContract end");
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" +contract.getFilename())
+                .body(bytes);
     }
 }

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -112,6 +112,7 @@ swagger.tokens.onboardingId=Onboarding's unique identifier
 swagger.tokens.retrieveOnboardingRequest=Service to retrieve a specific onboarding request
 swagger.tokens.approveOnboardingRequest=Service to approve a specific onboarding request
 swagger.tokens.rejectOnboardingRequest=Service to reject a specific onboarding request
+swagger.tokens.getContract=Service to download a specific onboarding contract
 
 swagger.onboarding.institutions.model.dpoData=Data Protection Officer (DPO) specific data
 swagger.onboarding.institutions.model.dpoData.address=DPO's address

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2ControllerTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.UUID;
 
@@ -174,11 +175,12 @@ public class TokenV2ControllerTest {
     @Test
     void getContract() throws Exception {
         String onboardingId = "onboardingId";
-        InputStream inputStream = Mockito.mock(InputStream.class);
+        String text = "String";
+        byte[] bytes= text.getBytes();
+        InputStream is = new ByteArrayInputStream(bytes);
         Resource resource = Mockito.mock(Resource.class);
         Mockito.when(tokenService.getContract(onboardingId)).thenReturn(resource);
-        Mockito.when(resource.getInputStream()).thenReturn(inputStream);
-        Mockito.when(inputStream.readAllBytes()).thenReturn(any());
+        Mockito.when(resource.getInputStream()).thenReturn(is);
 
         //when
         mvc.perform(MockMvcRequestBuilders

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2ControllerTest.java
@@ -11,10 +11,13 @@ import it.pagopa.selfcare.onboarding.web.model.OnboardingRequestResource;
 import it.pagopa.selfcare.onboarding.web.model.ReasonForRejectDto;
 import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapperImpl;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,6 +27,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.InputStream;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -165,5 +169,26 @@ public class TokenV2ControllerTest {
 
         verify(tokenService, times(1))
                 .rejectOnboarding(onboardingId, reason);
+    }
+
+    @Test
+    void getContract() throws Exception {
+        String onboardingId = "onboardingId";
+        InputStream inputStream = Mockito.mock(InputStream.class);
+        Resource resource = Mockito.mock(Resource.class);
+        Mockito.when(tokenService.getContract(onboardingId)).thenReturn(resource);
+        Mockito.when(resource.getInputStream()).thenReturn(inputStream);
+        Mockito.when(inputStream.readAllBytes()).thenReturn(any());
+
+        //when
+        mvc.perform(MockMvcRequestBuilders
+                        .get("/v2/tokens/{onboardingId}/contract", onboardingId)
+                        .accept(MediaType.APPLICATION_OCTET_STREAM_VALUE))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        verify(tokenService, times(1))
+                .getContract(onboardingId);
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add API getContract
- align ms-onboarding open-api
- align onboarding-backend open-api
- add unit tests

<!--- Describe your changes in detail -->

#### Motivation and Context
The implementation of this API was necessary because the contract will no longer be attached to email sent to institution, but it will be possible to download it through the same FE page where the upload button is also present.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Onboarding BFF and onboarding were started locally, then the API was invoked and it was verified that the contract was correctly retrieved.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.