### PR TITLE
[SELC-4354] fix: Added headers to the Response Entity

### DIFF
--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -183,6 +183,7 @@ public class TokenV2Controller {
 
             HttpHeaders headers = new HttpHeaders();
             headers.add(HttpHeaders.CONTENT_TYPE, APPLICATION_OCTET_STREAM_VALUE);
+            headers.add(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.CONTENT_DISPOSITION);
             headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + contract.getFilename());
             return ResponseEntity.ok()
                     .headers(headers)

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -181,7 +181,7 @@ public class TokenV2Controller {
             log.trace("getContract end");
             return ResponseEntity.ok()
                     .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + contract.getFilename())
-                    .header(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS)
+                    .header(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, HttpHeaders.CONTENT_DISPOSITION)
                     .body(byteArray);
         } finally {
             IOUtils.close(inputStream);

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -23,6 +23,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM_VALUE;
+
 @Slf4j
 @RestController
 @RequestMapping(value = "/v2/tokens", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -179,16 +181,9 @@ public class TokenV2Controller {
             byte[] byteArray = IOUtils.toByteArray(inputStream);
             log.trace("getContract end");
 
-            ContentDisposition contentDisposition = ContentDisposition.builder("attachment")
-                    .filename(contract.getFilename())
-                    .build();
-
             HttpHeaders headers = new HttpHeaders();
-            List<String> allowedHeaders = new ArrayList<>();
-            allowedHeaders.add(HttpHeaders.CONTENT_DISPOSITION);
-            headers.setAccessControlExposeHeaders(allowedHeaders);
-            headers.set("CUSTOM_HEADER", "test");
-            headers.setContentDisposition(contentDisposition);
+            headers.add(HttpHeaders.CONTENT_TYPE, APPLICATION_OCTET_STREAM_VALUE);
+            headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + contract.getFilename());
             return ResponseEntity.ok()
                     .headers(headers)
                     .body(byteArray);

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -14,15 +14,14 @@ import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.springframework.core.io.Resource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -179,9 +178,16 @@ public class TokenV2Controller {
             inputStream = contract.getInputStream();
             byte[] byteArray = IOUtils.toByteArray(inputStream);
             log.trace("getContract end");
+
+            ContentDisposition contentDisposition = ContentDisposition.builder("attachment")
+                    .filename(contract.getFilename())
+                    .build();
+
             HttpHeaders headers = new HttpHeaders();
-            headers.add(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.CONTENT_DISPOSITION);
-            headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + contract.getFilename());
+            List<String> allowedHeaders = new ArrayList<>();
+            allowedHeaders.add(HttpHeaders.CONTENT_DISPOSITION);
+            headers.setAccessControlExposeHeaders(allowedHeaders);
+            headers.setContentDisposition(contentDisposition);
             return ResponseEntity.ok()
                     .headers(headers)
                     .body(byteArray);

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -167,6 +167,7 @@ public class TokenV2Controller {
 
     @GetMapping(value = "/{onboardingId}/contract", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     @ResponseStatus(HttpStatus.OK)
+
     @ApiOperation(value = "", notes = "${swagger.tokens.getContract}")
     public ResponseEntity<byte[]> getContract(@ApiParam("${swagger.tokens.onboardingId}")
                                               @PathVariable("onboardingId")
@@ -180,8 +181,7 @@ public class TokenV2Controller {
             byte[] byteArray = IOUtils.toByteArray(inputStream);
             log.trace("getContract end");
             return ResponseEntity.ok()
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + contract.getFilename())
-                    .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.CONTENT_DISPOSITION)
+                    .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + contract.getFilename())
                     .body(byteArray);
         } finally {
             IOUtils.close(inputStream);

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -167,7 +167,6 @@ public class TokenV2Controller {
 
     @GetMapping(value = "/{onboardingId}/contract", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     @ResponseStatus(HttpStatus.OK)
-
     @ApiOperation(value = "", notes = "${swagger.tokens.getContract}")
     public ResponseEntity<byte[]> getContract(@ApiParam("${swagger.tokens.onboardingId}")
                                               @PathVariable("onboardingId")

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -187,6 +187,7 @@ public class TokenV2Controller {
             List<String> allowedHeaders = new ArrayList<>();
             allowedHeaders.add(HttpHeaders.CONTENT_DISPOSITION);
             headers.setAccessControlExposeHeaders(allowedHeaders);
+            headers.set("CUSTOM_HEADER", "test");
             headers.setContentDisposition(contentDisposition);
             return ResponseEntity.ok()
                     .headers(headers)

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -181,7 +181,7 @@ public class TokenV2Controller {
             log.trace("getContract end");
             return ResponseEntity.ok()
                     .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + contract.getFilename())
-                    .header(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, HttpHeaders.CONTENT_DISPOSITION)
+                    .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.CONTENT_DISPOSITION)
                     .body(byteArray);
         } finally {
             IOUtils.close(inputStream);

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -179,8 +179,11 @@ public class TokenV2Controller {
             inputStream = contract.getInputStream();
             byte[] byteArray = IOUtils.toByteArray(inputStream);
             log.trace("getContract end");
+            HttpHeaders headers = new HttpHeaders();
+            headers.add(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.CONTENT_DISPOSITION);
+            headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + contract.getFilename());
             return ResponseEntity.ok()
-                    .header(HttpHeaders.ACCESS_CONTROL_EXPOSE_HEADERS, HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + contract.getFilename())
+                    .headers(headers)
                     .body(byteArray);
         } finally {
             IOUtils.close(inputStream);

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/TokenV2Controller.java
@@ -181,6 +181,7 @@ public class TokenV2Controller {
             log.trace("getContract end");
             return ResponseEntity.ok()
                     .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + contract.getFilename())
+                    .header(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS)
                     .body(byteArray);
         } finally {
             IOUtils.close(inputStream);


### PR DESCRIPTION
#### List of Changes

- Added Content-Disposition header
- In order to read the previous one, a new header has been added to the response entity: ACCESS_CONTROL_EXPOSE_HEADERS

#### Motivation and Context

These changes have been implemented in order to allow clients to read the name of file given as response from the API
