### PR TITLE
[SELC - 4465] feat: Removal of mandatory requirements for taxCode, vatNumber, recip…

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2038,7 +2038,7 @@
       },
       "BillingDataDto" : {
         "title" : "BillingDataDto",
-        "required" : [ "businessName", "digitalAddress", "recipientCode", "registeredOffice", "taxCode", "vatNumber", "zipCode" ],
+        "required" : [ "businessName", "digitalAddress", "registeredOffice", "zipCode" ],
         "type" : "object",
         "properties" : {
           "businessName" : {
@@ -2459,7 +2459,6 @@
       },
       "InstitutionLocationDataDto" : {
         "title" : "InstitutionLocationDataDto",
-        "required" : [ "city", "country", "county" ],
         "type" : "object",
         "properties" : {
           "city" : {
@@ -2607,7 +2606,7 @@
       },
       "OnboardingProductDto" : {
         "title" : "OnboardingProductDto",
-        "required" : [ "billingData", "institutionType", "productId", "taxCode", "users" ],
+        "required" : [ "billingData", "institutionType", "productId", "users" ],
         "type" : "object",
         "properties" : {
           "additionalInformations" : {

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/BillingDataDto.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/BillingDataDto.java
@@ -29,17 +29,15 @@ public class BillingDataDto {
     @NotBlank
     private String zipCode;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCode}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCode}")
+    @JsonProperty
     private String taxCode;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.vatNumber}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.vatNumber}")
+    @JsonProperty
     private String vatNumber;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.recipientCode}", required = true)
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.recipientCode}")
     private String recipientCode;
 
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.publicServices}")

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/InstitutionLocationDataDto.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/InstitutionLocationDataDto.java
@@ -4,23 +4,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
-import javax.validation.constraints.NotBlank;
-
 @Data
 public class InstitutionLocationDataDto {
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.city}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.city}")
+    @JsonProperty
     private String city;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.county}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.county}")
+    @JsonProperty
     private String county;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.country}", required = true)
-    @JsonProperty(required = true)
-    @NotBlank
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.country}")
+    @JsonProperty
     private String country;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingProductDto.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingProductDto.java
@@ -56,8 +56,7 @@ public class OnboardingProductDto {
     @NotNull
     private String productId;
 
-    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCode}", required = true)
-    @NotNull
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCode}")
     private String taxCode;
 
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.subunitCode}")


### PR DESCRIPTION
…ientCode, city, county, country

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Removal of mandatory requirements during onboarding request for:
- taxCode
- vatNumber
- recipientCode
- city
- county
- country

#### Motivation and Context

These changes were necessary because SC must also allow foreign insurance companies that do not have the fields described above to join Interop

#### How Has This Been Tested?

the microservice was started locally and it was verified that the request was forwarded despite the absence of those fields

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.