### PR TITLE
SELC-4720 feature: added originId mapping using ivassCode

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/OnboardingData.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/OnboardingData.java
@@ -40,6 +40,7 @@ public class OnboardingData {
     private InstitutionUpdate institutionUpdate;
     private InstitutionType institutionType;
     private String origin;
+    private String originId;
     private String pricingPlan;
     private String businessName;
     private boolean existsInRegistry;

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -4,6 +4,13 @@
     "title" : "onboarding-ms API",
     "version" : "1.0.0"
   },
+  "servers" : [ {
+    "url" : "http://localhost:8080",
+    "description" : "Auto generated value"
+  }, {
+    "url" : "http://0.0.0.0:8080",
+    "description" : "Auto generated value"
+  } ],
   "paths" : {
     "/v1/onboarding" : {
       "get" : {
@@ -759,11 +766,9 @@
         }
       },
       "BillingRequest" : {
-        "required" : [ "vatNumber" ],
         "type" : "object",
         "properties" : {
           "vatNumber" : {
-            "minLength" : 1,
             "type" : "string"
           },
           "recipientCode" : {
@@ -814,14 +819,13 @@
         }
       },
       "InstitutionBaseRequest" : {
-        "required" : [ "institutionType", "taxCode", "digitalAddress" ],
+        "required" : [ "institutionType", "digitalAddress" ],
         "type" : "object",
         "properties" : {
           "institutionType" : {
             "$ref" : "#/components/schemas/InstitutionType"
           },
           "taxCode" : {
-            "minLength" : 1,
             "type" : "string"
           },
           "subunitCode" : {
@@ -832,6 +836,9 @@
           },
           "origin" : {
             "$ref" : "#/components/schemas/Origin"
+          },
+          "originId" : {
+            "type" : "string"
           },
           "city" : {
             "type" : "string"
@@ -953,14 +960,13 @@
         "type" : "string"
       },
       "InstitutionPspRequest" : {
-        "required" : [ "institutionType", "taxCode", "digitalAddress", "paymentServiceProvider" ],
+        "required" : [ "institutionType", "digitalAddress", "paymentServiceProvider" ],
         "type" : "object",
         "properties" : {
           "institutionType" : {
             "$ref" : "#/components/schemas/InstitutionType"
           },
           "taxCode" : {
-            "minLength" : 1,
             "type" : "string"
           },
           "subunitCode" : {
@@ -971,6 +977,9 @@
           },
           "origin" : {
             "$ref" : "#/components/schemas/Origin"
+          },
+          "originId" : {
+            "type" : "string"
           },
           "city" : {
             "type" : "string"
@@ -1306,6 +1315,7 @@
             "$ref" : "#/components/schemas/Origin"
           },
           "digitalAddress" : {
+            "pattern" : "\\S",
             "type" : "string"
           }
         }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/OnboardingMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/OnboardingMapper.java
@@ -42,6 +42,9 @@ public interface OnboardingMapper {
                 .map(InstitutionPaSubunitType::valueOf)
                 .orElse(null));
         institution.setOrigin(Optional.ofNullable(onboardingData.getOrigin()).map(Origin::fromValue).orElse(null));
+        if(Objects.nonNull(onboardingData.getOriginId())) {
+            institution.setOriginId(onboardingData.getOriginId());
+        }
         if(Objects.nonNull(onboardingData.getLocation())) {
             institution.setCity(onboardingData.getLocation().getCity());
             institution.setCountry(onboardingData.getLocation().getCountry());
@@ -77,6 +80,9 @@ public interface OnboardingMapper {
                 .orElse(null));
 
         institutionPsp.setOrigin(Optional.ofNullable(onboardingData.getOrigin()).map(Origin::fromValue).orElse(null));
+        if(Objects.nonNull(onboardingData.getOriginId())) {
+            institutionPsp.setOriginId(onboardingData.getOriginId());
+        }
         if(Objects.nonNull(onboardingData.getLocation())) {
             institutionPsp.setCity(onboardingData.getLocation().getCity());
             institutionPsp.setCountry(onboardingData.getLocation().getCountry());

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/OnboardingMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/OnboardingMapper.java
@@ -12,7 +12,6 @@ import org.mapstruct.Named;
 
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public interface OnboardingMapper {
@@ -57,7 +56,7 @@ public interface OnboardingMapper {
         institution.geographicTaxonomies(Optional.ofNullable(onboardingData.getInstitutionUpdate().getGeographicTaxonomies())
                 .map(geotaxes -> geotaxes.stream()
                         .map(this::toGeographicTaxonomyDto)
-                        .collect(Collectors.toList()))
+                        .toList())
                 .orElse(null));
         institution.rea(onboardingData.getInstitutionUpdate().getRea());
         institution.shareCapital(onboardingData.getInstitutionUpdate().getShareCapital());
@@ -95,7 +94,7 @@ public interface OnboardingMapper {
         institutionPsp.geographicTaxonomies(Optional.ofNullable(onboardingData.getInstitutionUpdate().getGeographicTaxonomies())
                 .map(geotaxes -> geotaxes.stream()
                     .map(this::toGeographicTaxonomyDto)
-                    .collect(Collectors.toList()))
+                    .toList())
                 .orElse(null));
         institutionPsp.rea(onboardingData.getInstitutionUpdate().getRea());
         institutionPsp.shareCapital(onboardingData.getInstitutionUpdate().getShareCapital());

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
@@ -52,6 +52,7 @@ public class OnboardingMsConnectorImplTest {
         institutionUpdate.setDescription("description");
         onboardingData.setBilling(billing);
         onboardingData.setUsers(List.of(mockInstance(new User())));
+        onboardingData.setOriginId("originId");
         onboardingData.setInstitutionUpdate(institutionUpdate);
         // when
         onboardingMsConnector.onboarding(onboardingData);

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/OnboardingResourceMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/OnboardingResourceMapper.java
@@ -28,6 +28,7 @@ public interface OnboardingResourceMapper {
     @Mapping(source = "assistanceContacts.supportEmail", target = "institutionUpdate.supportEmail")
     @Mapping(source = "assistanceContacts.supportPhone", target = "institutionUpdate.supportPhone")
     @Mapping(source = "additionalInformations", target = "institutionUpdate.additionalInformations")
+    @Mapping(source = "ivassCode", target = "originId")
     OnboardingData toEntity(OnboardingProductDto dto);
 
     @Mapping(source = "billingData", target = "billing")


### PR DESCRIPTION
#### List of Changes

updated selfcare-onboarding openapi adding originId field in new onboarding API, and mapped originId field with ivassCode in DTOs 

#### Motivation and Context

It is necessary to add the originId field and map it to the ivassCode for onboarding foreign insurance in the objects used by the onboarding API

#### How Has This Been Tested?
local env

#### Screenshots (if appropriate):


#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.