### PR TITLE
[SELC - 4787] feat: added TaxCodeSfe to Onboarding UO

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2098,6 +2098,10 @@
             "type" : "string",
             "description" : "Institution's taxCode"
           },
+          "taxCodeSfe" : {
+            "type" : "string",
+            "description" : "Institution's taxCodeSfe for electronic invoicing"
+          },
           "vatNumber" : {
             "type" : "string",
             "description" : "Institution's VAT number"
@@ -2460,6 +2464,10 @@
             "type" : "string",
             "description" : "Billing recipient code, not required only for institutionType SA"
           },
+          "taxCodeSfe" : {
+            "type" : "string",
+            "description" : "Institution's taxCodeSfe for electronic invoicing"
+          },
           "vatNumber" : {
             "type" : "string",
             "description" : "Institution's VAT number"
@@ -2699,6 +2707,10 @@
           "taxCode" : {
             "type" : "string",
             "description" : "Institution's taxCode"
+          },
+          "taxCodeSfe" : {
+            "type" : "string",
+            "description" : "Institution's taxCodeSfe for electronic invoicing"
           },
           "users" : {
             "type" : "array",

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/OnboardingData.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/OnboardingData.java
@@ -27,6 +27,7 @@ public class OnboardingData {
 
     private String institutionExternalId;
     private String taxCode;
+    private String taxCodeSfe;
     private String subunitCode;
     private String subunitType;
     private String productId;

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -881,6 +881,9 @@
           "taxCode" : {
             "type" : "string"
           },
+          "taxCodeSfe" : {
+            "type" : "string"
+          },
           "subunitCode" : {
             "type" : "string"
           },
@@ -1022,6 +1025,9 @@
           "taxCode" : {
             "type" : "string"
           },
+          "taxCodeSfe" : {
+            "type" : "string"
+          },
           "subunitCode" : {
             "type" : "string"
           },
@@ -1098,6 +1104,9 @@
             "$ref" : "#/components/schemas/InstitutionType"
           },
           "taxCode" : {
+            "type" : "string"
+          },
+          "taxCodeSfe" : {
             "type" : "string"
           },
           "subunitCode" : {

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/BillingDataDto.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/BillingDataDto.java
@@ -30,6 +30,9 @@ public class BillingDataDto {
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCode}")
     private String taxCode;
 
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCodeSfe}")
+    private String taxCodeSfe;
+
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.vatNumber}")
     private String vatNumber;
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingProductDto.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingProductDto.java
@@ -57,6 +57,9 @@ public class OnboardingProductDto {
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCode}")
     private String taxCode;
 
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCodeSfe}")
+    private String taxCodeSfe;
+
     @ApiModelProperty(value = "${swagger.onboarding.institutions.model.subunitCode}")
     private String subunitCode;
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingRequestResource.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/OnboardingRequestResource.java
@@ -82,6 +82,9 @@ public class OnboardingRequestResource {
         @JsonProperty(required = true)
         private String fiscalCode;
 
+        @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCodeSfe}")
+        private String taxCodeSfe;
+
         @ApiModelProperty(value = "${swagger.onboarding.institutions.model.vatNumber}", required = true)
         private String vatNumber;
 

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -29,6 +29,7 @@ swagger.onboarding.institutions.model.address=Institution's physical address
 swagger.onboarding.institutions.model.digitalAddress=Institution's digitalAddress
 swagger.onboarding.institutions.model.zipCode=Institution's zipCode
 swagger.onboarding.institutions.model.taxCode=Institution's taxCode
+swagger.onboarding.institutions.model.taxCodeSfe=Institution's taxCodeSfe for electronic invoicing
 swagger.onboarding.institutions.model.subunitCode=Institution's subunitCode
 swagger.onboarding.institutions.model.subunitType=Institution's subunitType
 swagger.onboarding.institutions.model.billingData=Institution's billing information


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added taxCodeSfe to:

- OnboardingData
- BillingDataDto
- OnboardingProductDto
- OnboardingRequestResource

#### Motivation and Context

The addition of this new field is necessary as some AOO/UO have a taxCode different from that of the central body, which they use for invoicing, called SFE taxCode.

#### How Has This Been Tested?

The microservice has been started locally and it has been verified that it is present in the Request

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.