### PR TITLE
[SELCA-4947] feat: refactor getInstitutionOnboardingData using institutionId

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -40,6 +40,14 @@
         "description" : "The service retrieves all the onboarded institutions related to the logged user",
         "operationId" : "getInstitutionsUsingGET",
         "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
           "name" : "productFilter",
           "in" : "query",
           "description" : "A product to filter the institutions based on whether the institution has an ACTIVE onboarding on the specified product.",
@@ -577,23 +585,14 @@
     "/v1/institutions/onboarding/" : {
       "get" : {
         "tags" : [ "institutions" ],
-        "summary" : "getInstitutionOnboardingInfo",
+        "summary" : "getInstitutionOnboardingInfoById",
         "description" : "The service retrieves the institutions Manager and institution informations",
-        "operationId" : "getInstitutionOnboardingInfoUsingGET",
+        "operationId" : "getInstitutionOnboardingInfoByIdUsingGET",
         "parameters" : [ {
-          "name" : "taxCode",
+          "name" : "institutionId",
           "in" : "query",
-          "description" : "Institution's taxCode",
+          "description" : "Institution's unique internal Id",
           "required" : true,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "subunitCode",
-          "in" : "query",
-          "description" : "Institution's subunitCode",
-          "required" : false,
           "style" : "form",
           "schema" : {
             "type" : "string"
@@ -995,7 +994,7 @@
         "tags" : [ "institutions" ],
         "summary" : "getInstitutionOnboardingInfo",
         "description" : "The service retrieves the institutions Manager and institution informations",
-        "operationId" : "getInstitutionOnboardingInfoUsingGET_1",
+        "operationId" : "getInstitutionOnboardingInfoUsingGET",
         "parameters" : [ {
           "name" : "externalInstitutionId",
           "in" : "path",

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/PartyConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/PartyConnector.java
@@ -24,6 +24,8 @@ public interface PartyConnector {
 
     Institution getInstitutionByExternalId(String externalInstitutionId);
 
+    Institution getInstitutionById(String institutionId);
+
     List<OnboardingResource> getOnboardings(String institutionId, String productId);
 
     Institution createInstitutionFromIpa(String taxCode, String subunitCode, String subunitType);

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImpl.java
@@ -17,6 +17,7 @@ import it.pagopa.selfcare.onboarding.connector.rest.mapper.InstitutionMapper;
 import it.pagopa.selfcare.onboarding.connector.rest.model.*;
 import it.pagopa.selfcare.user.generated.openapi.v1.dto.UserInstitutionResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.owasp.encoder.Encode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
@@ -228,7 +229,7 @@ class PartyConnectorImpl implements PartyConnector {
     @Override
     public Institution getInstitutionById(String institutionId) {
         log.trace("getInstitutionById start");
-        log.debug("getInstitutionById institutionId = {}", institutionId);
+        log.debug("getInstitutionById institutionId = {}", Encode.forJava(institutionId));
         Assert.hasText(institutionId, REQUIRED_INSTITUTION_ID_MESSAGE);
         InstitutionResponse institutionResponse = restClient.getInstitutionById(institutionId);
         Institution result = institutionMapper.toEntity(institutionResponse);

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImpl.java
@@ -241,7 +241,7 @@ class PartyConnectorImpl implements PartyConnector {
     @Override
     public List<OnboardingResource> getOnboardings(String institutionId, String productId) {
         log.trace("getOnboardings start");
-        log.debug("getOnboardings institutionId = {}", institutionId);
+        log.debug("getOnboardings institutionId = {}", Encode.forJava(institutionId));
         Assert.hasText(institutionId, REQUIRED_INSTITUTION_ID_MESSAGE);
         OnboardingsResponse onboardings = restClient.getOnboardings(institutionId, productId);
         List<OnboardingResource> onboardingResources = onboardings.getOnboardings().stream()

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImpl.java
@@ -226,6 +226,18 @@ class PartyConnectorImpl implements PartyConnector {
     }
 
     @Override
+    public Institution getInstitutionById(String institutionId) {
+        log.trace("getInstitutionById start");
+        log.debug("getInstitutionById institutionId = {}", institutionId);
+        Assert.hasText(institutionId, REQUIRED_INSTITUTION_ID_MESSAGE);
+        InstitutionResponse institutionResponse = restClient.getInstitutionById(institutionId);
+        Institution result = institutionMapper.toEntity(institutionResponse);
+        log.debug("getInstitutionById result = {}", result);
+        log.trace("getInstitutionById end");
+        return result;
+    }
+
+    @Override
     public List<OnboardingResource> getOnboardings(String institutionId, String productId) {
         log.trace("getOnboardings start");
         log.debug("getOnboardings institutionId = {}", institutionId);

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/client/PartyProcessRestClient.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/client/PartyProcessRestClient.java
@@ -95,4 +95,8 @@ public interface PartyProcessRestClient extends OnboardingApi {
                           @RequestParam("subunitCode") String subunitCode,
                           @RequestParam("productId") String productId);
 
+    @GetMapping(value = "${rest-client.party-process.getInstitutionById.path}", produces = APPLICATION_JSON_VALUE)
+    @ResponseBody
+    InstitutionResponse getInstitutionById(@PathVariable("institutionId") String institutionId);
+
 }

--- a/connector/rest/src/main/resources/config/party-process-rest-client.properties
+++ b/connector/rest/src/main/resources/config/party-process-rest-client.properties
@@ -10,6 +10,7 @@ rest-client.party-process.getOnBoardingInfo.path=/onboarding/info
 rest-client.party-process.getOnboardings.path=/institutions/{institutionId}/onboardings/
 rest-client.party-process.getInstitutions.path=/institutions/
 rest-client.party-process.getInstitutionByExternalId.path=/external/institutions/{externalId}
+rest-client.party-process.getInstitutionById.path=/institutions/{institutionId}
 rest-client.party-process.createInstitutionFromIpa.path=/institutions/from-ipa/
 rest-client.party-process.createInstitutionFromAnac.path=/institutions/from-anac/
 rest-client.party-process.createInstitutionFromIvass.path=/institutions/from-ivass/

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/PartyConnectorImplTest.java
@@ -789,6 +789,46 @@ class PartyConnectorImplTest {
     }
 
     @Test
+    void getInstitutionById_nullInstitutionId() {
+        //given
+        String institutionId = null;
+        //when
+        Executable exe = () -> partyConnector.getInstitutionById(institutionId);
+        //then
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, exe);
+        assertEquals(REQUIRED_INSTITUTION_ID_MESSAGE, e.getMessage());
+        Mockito.verifyNoInteractions(restClientMock);
+    }
+
+
+    @Test
+    void getInstitutionById() {
+        //given
+        String institutionId = "institutionId";
+        InstitutionResponse institutionResponseMock = mockInstance(new InstitutionResponse());
+        institutionResponseMock.setGeographicTaxonomies(List.of(mockInstance(new GeographicTaxonomy())));
+        when(restClientMock.getInstitutionById(institutionId))
+                .thenReturn(institutionResponseMock);
+        //when
+        Institution institution = partyConnector.getInstitutionById(institutionId);
+        //then
+        assertNotNull(institution);
+        assertEquals(institutionResponseMock.getExternalId(), institution.getExternalId());
+        assertEquals(institutionResponseMock.getDescription(), institution.getDescription());
+        assertEquals(institutionResponseMock.getAddress(), institution.getAddress());
+        assertEquals(institutionResponseMock.getTaxCode(), institution.getTaxCode());
+        assertEquals(institutionResponseMock.getId(), institution.getId());
+        assertEquals(institutionResponseMock.getZipCode(), institution.getZipCode());
+        assertEquals(institutionResponseMock.getDigitalAddress(), institution.getDigitalAddress());
+        assertEquals(institutionResponseMock.getInstitutionType(), institution.getInstitutionType());
+        assertEquals(institutionResponseMock.getGeographicTaxonomies().get(0).getCode(), institution.getGeographicTaxonomies().get(0).getCode());
+        assertEquals(institutionResponseMock.getGeographicTaxonomies().get(0).getDesc(), institution.getGeographicTaxonomies().get(0).getDesc());
+        verify(restClientMock, times(1))
+                .getInstitutionById(institutionId);
+        verifyNoMoreInteractions(restClientMock);
+    }
+
+    @Test
     void getOnboardings_emptyOnboardings() {
         // given
         String institutionId = "institutionId";

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
@@ -23,7 +23,7 @@ public interface InstitutionService {
 
     Collection<InstitutionInfo> getInstitutions(String productId, String userId);
 
-    InstitutionOnboardingData getInstitutionOnboardingData(String taxCode, String subunitCode, String productId);
+    InstitutionOnboardingData getInstitutionOnboardingDataById(String institutionId, String productId);
 
     InstitutionOnboardingData getInstitutionOnboardingData(String externalInstitutionId, String productId);
 

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -35,6 +35,7 @@ import it.pagopa.selfcare.onboarding.core.exception.UpdateNotAllowedException;
 import it.pagopa.selfcare.onboarding.core.mapper.InstitutionInfoMapper;
 import it.pagopa.selfcare.onboarding.core.strategy.OnboardingValidationStrategy;
 import lombok.extern.slf4j.Slf4j;
+import org.owasp.encoder.Encode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
@@ -308,7 +309,7 @@ class InstitutionServiceImpl implements InstitutionService {
     @Override
     public InstitutionOnboardingData getInstitutionOnboardingDataById(String institutionId, String productId) {
         log.trace("getInstitutionOnboardingData start");
-        log.debug("getInstitutionOnboardingData institutionId = {}, productId = {}", institutionId, productId);
+        log.debug("getInstitutionOnboardingData institutionId = {}, productId = {}", Encode.forJava(institutionId), Encode.forJava(productId));
         Assert.hasText(institutionId, REQUIRED_INSTITUTION_ID_MESSAGE);
         Assert.hasText(productId, A_PRODUCT_ID_IS_REQUIRED);
 

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -306,22 +306,18 @@ class InstitutionServiceImpl implements InstitutionService {
 
 
     @Override
-    public InstitutionOnboardingData getInstitutionOnboardingData(String taxCode, String subunitCode, String productId) {
+    public InstitutionOnboardingData getInstitutionOnboardingDataById(String institutionId, String productId) {
         log.trace("getInstitutionOnboardingData start");
-        log.debug("getInstitutionOnboardingData taxCode = {}, productId = {}", taxCode, productId);
-        Assert.hasText(taxCode, REQUIRED_INSTITUTION_ID_MESSAGE);
+        log.debug("getInstitutionOnboardingData institutionId = {}, productId = {}", institutionId, productId);
+        Assert.hasText(institutionId, REQUIRED_INSTITUTION_ID_MESSAGE);
         Assert.hasText(productId, A_PRODUCT_ID_IS_REQUIRED);
 
-        List<Institution> institutions = partyConnector.getInstitutionsByTaxCodeAndSubunitCode(taxCode, subunitCode);
-        Institution institution = institutions.stream()
-                .findFirst()
-                .orElseThrow(() -> new ResourceNotFoundException(String.format("Institution with taxCode %s and subunitCode %s not found", taxCode, subunitCode)));
-
-        List<OnboardingResource> onboardingsResource = partyConnector.getOnboardings(institution.getId(), productId);
+        List<OnboardingResource> onboardingsResource = partyConnector.getOnboardings(institutionId, productId);
         OnboardingResource onboardingResource = onboardingsResource.stream()
                 .findFirst()
-                .orElseThrow(() -> new ResourceNotFoundException(String.format("Institution with taxCode %s and subunitCode %s not found", taxCode, subunitCode)));
+                .orElseThrow(() -> new ResourceNotFoundException(String.format("Onboarding for institutionId %s not found", institutionId)));
 
+        Institution institution = partyConnector.getInstitutionById(institutionId);
         InstitutionOnboardingData result = new InstitutionOnboardingData();
         InstitutionInfo institutionInfo = institutionMapper.toInstitutionInfo(institution);
         institutionInfo.setPricingPlan(onboardingResource.getPricingPlan());

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>selc-commons-base</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.owasp.encoder</groupId>
+            <artifactId>encoder</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+        <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>selc-commons-base</artifactId>
             <type>test-jar</type>

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
@@ -20,6 +20,7 @@ import it.pagopa.selfcare.onboarding.web.model.*;
 import it.pagopa.selfcare.onboarding.web.model.mapper.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.owasp.encoder.Encode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -101,7 +102,7 @@ public class InstitutionController {
                                                                           @RequestParam("productId")
                                                                           String productId) {
         log.trace("getInstitutionOnboardingInfoById start");
-        log.debug("getInstitutionOnboardingInfoById institutionId = {}, productId = {}", institutionId, productId);
+        log.debug("getInstitutionOnboardingInfoById institutionId = {}, productId = {}", Encode.forJava(institutionId), Encode.forJava(productId));
         InstitutionOnboardingData institutionOnboardingData = institutionService.getInstitutionOnboardingDataById(institutionId, productId);
         InstitutionOnboardingInfoResource result = onboardingInstitutionInfoMapper.toResource(institutionOnboardingData);
         log.debug("getInstitutionOnboardingInfoById result = {}", result);

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
@@ -94,21 +94,18 @@ public class InstitutionController {
     @GetMapping(value = "/onboarding/")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.getInstitutionOnboardingInfo}")
-    public InstitutionOnboardingInfoResource getInstitutionOnboardingInfo(@ApiParam("${swagger.onboarding.institutions.model.taxCode}")
-                                                                          @RequestParam("taxCode")
-                                                                          String taxCode,
-                                                                          @ApiParam("${swagger.onboarding.institutions.model.subunitCode}")
-                                                                          @RequestParam(value = "subunitCode", required = false)
-                                                                          String subunitCode,
+    public InstitutionOnboardingInfoResource getInstitutionOnboardingInfoById(@ApiParam("${swagger.onboarding.institutions.model.id}")
+                                                                          @RequestParam("institutionId")
+                                                                          String institutionId,
                                                                           @ApiParam("${swagger.onboarding.product.model.id}")
                                                                           @RequestParam("productId")
                                                                           String productId) {
-        log.trace("getInstitutionOnBoardingInfo start");
-        log.debug("getInstitutionOnBoardingInfo taxCode = {}, subunitCode = {}, productId = {}", taxCode, subunitCode, productId);
-        InstitutionOnboardingData institutionOnboardingData = institutionService.getInstitutionOnboardingData(taxCode, subunitCode, productId);
+        log.trace("getInstitutionOnboardingInfoById start");
+        log.debug("getInstitutionOnboardingInfoById institutionId = {}, productId = {}", institutionId, productId);
+        InstitutionOnboardingData institutionOnboardingData = institutionService.getInstitutionOnboardingDataById(institutionId, productId);
         InstitutionOnboardingInfoResource result = onboardingInstitutionInfoMapper.toResource(institutionOnboardingData);
-        log.debug("getInstitutionOnBoardingInfo result = {}", result);
-        log.trace("getInstitutionOnBoardingInfo end");
+        log.debug("getInstitutionOnboardingInfoById result = {}", result);
+        log.trace("getInstitutionOnboardingInfoById end");
         return result;
     }
 

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionControllerTest.java
@@ -209,12 +209,12 @@ class InstitutionControllerTest {
 
         InstitutionOnboardingData institutionOnboardingData = new InstitutionOnboardingData();
         institutionOnboardingData.setInstitution(institutionInfo);
-        when(institutionServiceMock.getInstitutionOnboardingData(institutionInfo.getTaxCode(),null,productId))
+        when(institutionServiceMock.getInstitutionOnboardingDataById(institutionInfo.getId(),productId))
                 .thenReturn(institutionOnboardingData);
         //when
         MvcResult result = mvc.perform(MockMvcRequestBuilders
                         .get(BASE_URL + "/onboarding/")
-                        .queryParam("taxCode", institutionInfo.getTaxCode())
+                        .queryParam("institutionId", institutionInfo.getId())
                         .queryParam("productId", productId)
                         .contentType(APPLICATION_JSON_VALUE)
                         .accept(APPLICATION_JSON_VALUE))


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* refactor endpoint GET /institutions/onboarding replacing path parem taxcode with institutionId
* Updated any related tests to accommodate the new implementation.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This endpoint is used only for onboarding prod-io-premium. This [PR](https://github.com/pagopa/selfcare-onboarding-backend/pull/307) has done an refactor where frontend retrieve a list of institutions with institutionId instead of taxCode.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.