### PR TITLE
chore: Set Custom Operation ID for ApiOperation Annotations

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -587,7 +587,7 @@
         "tags" : [ "institutions" ],
         "summary" : "getInstitutionOnboardingInfoById",
         "description" : "The service retrieves the institutions Manager and institution informations",
-        "operationId" : "getInstitutionOnboardingInfoByIdUsingGET",
+        "operationId" : "getInstitutionOnboardingInfoUsingGET",
         "parameters" : [ {
           "name" : "institutionId",
           "in" : "query",
@@ -994,7 +994,7 @@
         "tags" : [ "institutions" ],
         "summary" : "getInstitutionOnboardingInfo",
         "description" : "The service retrieves the institutions Manager and institution informations",
-        "operationId" : "getInstitutionOnboardingInfoUsingGET",
+        "operationId" : "getInstitutionOnboardingInfoUsingGET_1",
         "parameters" : [ {
           "name" : "externalInstitutionId",
           "in" : "path",

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
@@ -94,7 +94,7 @@ public class InstitutionController {
 
     @GetMapping(value = "/onboarding/")
     @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.getInstitutionOnboardingInfo}")
+    @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.getInstitutionOnboardingInfo}", nickname = "getInstitutionOnboardingInfoUsingGET")
     public InstitutionOnboardingInfoResource getInstitutionOnboardingInfoById(@ApiParam("${swagger.onboarding.institutions.model.id}")
                                                                           @RequestParam("institutionId")
                                                                           String institutionId,
@@ -285,7 +285,7 @@ public class InstitutionController {
     @Deprecated(forRemoval = true)
     @GetMapping(value = "/{externalInstitutionId}/products/{productId}/onboarded-institution-info")
     @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.getInstitutionOnboardingInfo}")
+    @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.getInstitutionOnboardingInfo}", nickname = "getInstitutionOnboardingInfoUsingGET_1")
     public InstitutionOnboardingInfoResource getInstitutionOnboardingInfo(@ApiParam("${swagger.onboarding.institutions.model.externalId}")
                                                                           @PathVariable("externalInstitutionId")
                                                                           String externalInstitutionId,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Updated ApiOperation annotations that has changed to include a custom operationId.
* Ensured that these endpoint has a previous operationId to prevent naming conflicts and ensure smooth updates on APIM.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request introduces a custom **operationId** within the `ApiOperation` annotations to ensure consistent updates of our APIs on Azure API Management (APIM). The custom operationId is crucial to avoid issues that arise when the operationId changes, which can prevent the API from updating correctly. Without a custom operationId, renaming an operationId necessitates deleting and recreating the entire API group, leading to temporary service disruptions and loss of analytics data.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.