### PR TITLE
[SELC-4903] feat: added OnboardingFunctionsApiClient and codegen execution in pom

### DIFF
--- a/connector/rest/docs/openapi/api-selfcare-onboarding-functions-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-functions-docs.json
@@ -1,0 +1,55 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "FDRestClient API",
+    "description": "API for checking organization details",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "Organization",
+      "description": "API for organization operations"
+    }
+  ],
+  "paths": {
+    "/api/CheckOrganization": {
+      "head": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "Check Organization",
+        "operationId": "checkOrganization",
+        "parameters": [
+          {
+            "name": "fiscalCode",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "vatNumber",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/connector/rest/pom.xml
+++ b/connector/rest/pom.xml
@@ -142,6 +142,37 @@
                             </configOptions>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>selfcare-onboarding-functions</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <inputSpec>${project.basedir}/docs/openapi/api-selfcare-onboarding-functions-docs.json</inputSpec>
+                            <generatorName>spring</generatorName>
+                            <library>spring-cloud</library>
+                            <modelNameSuffix />
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <configOptions>
+                                <generateForOpenFeign>true</generateForOpenFeign>
+                                <basePackage>${project.groupId}.onboarding_functions.generated.openapi.v1</basePackage>
+                                <modelPackage>${project.groupId}.onboarding_functions.generated.openapi.v1.dto</modelPackage>
+                                <apiPackage>${project.groupId}.onboarding_functions.generated.openapi.v1.api</apiPackage>
+                                <configPackage>${project.groupId}.onboarding_functions.generated.openapi.v1.config</configPackage>
+                                <additionalModelTypeAnnotations>@lombok.Builder; @lombok.NoArgsConstructor; @lombok.AllArgsConstructor</additionalModelTypeAnnotations>
+                                <dateLibrary>java8-localdatetime</dateLibrary>
+                                <delegatePattern>true</delegatePattern>
+                                <interfaceOnly>true</interfaceOnly>
+                                <annotationLibrary>none</annotationLibrary>
+                                <documentationProvider>source</documentationProvider>
+                                <openApiNullable>false</openApiNullable>
+                                <skipDefaultInterface>false</skipDefaultInterface>
+                                <useTags>true</useTags>
+                            </configOptions>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/client/OnboardingFunctionsApiClient.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/client/OnboardingFunctionsApiClient.java
@@ -1,0 +1,9 @@
+package it.pagopa.selfcare.onboarding.connector.rest.client;
+
+
+import it.pagopa.selfcare.onboarding_functions.generated.openapi.v1.api.OrganizationApi;
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(name = "${rest-client.onboarding-functions-api.serviceCode}", url = "${rest-client.onboarding-functions-api.baseUrl}")
+public interface OnboardingFunctionsApiClient extends OrganizationApi {
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/config/OnboardingFunctionsClientConfig.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/config/OnboardingFunctionsClientConfig.java
@@ -1,0 +1,15 @@
+package it.pagopa.selfcare.onboarding.connector.rest.config;
+
+import it.pagopa.selfcare.commons.connector.rest.config.RestClientBaseConfig;
+import it.pagopa.selfcare.onboarding.connector.rest.client.OnboardingFunctionsApiClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@Import(RestClientBaseConfig.class)
+@EnableFeignClients(clients = {OnboardingFunctionsApiClient.class})
+@PropertySource("classpath:config/onboarding-functions-rest-client.properties")
+public class OnboardingFunctionsClientConfig {
+}

--- a/connector/rest/src/main/resources/config/onboarding-functions-rest-client.properties
+++ b/connector/rest/src/main/resources/config/onboarding-functions-rest-client.properties
@@ -1,0 +1,5 @@
+rest-client.onboarding-functions-api.serviceCode=onboarding-functions-api
+rest-client.onboarding-functions-api.baseUrl=${ONBOARDING_FUNCTIONS_URL:https://localhost:8080}
+feign.client.config.onboarding-functions-api.requestInterceptors[0]=it.pagopa.selfcare.commons.connector.rest.interceptor.AuthorizationHeaderInterceptor
+feign.client.config.onboarding-functions-api.errorDecoder=it.pagopa.selfcare.onboarding.connector.rest.decoder.FeignErrorDecoder
+feign.client.config.onboarding-functions-api.defaultRequestHeaders.x-functions-key[0]=${ONBOARDING-FUNCTIONS-API-KEY:example-api-key}


### PR DESCRIPTION
#### List of Changes

1. Added swagger for onboarding functions to invoke checkOrganization api.
2. Added client feign and configurations.

#### Motivation and Context

The checkOrganization api was created as an http azure function on ms-onboarding for phasing out functions from external interceptor

#### How Has This Been Tested?
local env

#### Screenshots (if appropriate):


#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.