### PR TITLE
[SELC-4903] feat: replaced external-interceptor connector with onboarding-functions connector

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingFunctionsConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingFunctionsConnector.java
@@ -1,0 +1,5 @@
+package it.pagopa.selfcare.onboarding.connector.api;
+
+public interface OnboardingFunctionsConnector {
+    void checkOrganization(String fiscalCode, String vatNumber);
+}

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-functions-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-functions-docs.json
@@ -1,0 +1,55 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "FDRestClient API",
+    "description": "API for checking organization details",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "Organization",
+      "description": "API for organization operations"
+    }
+  ],
+  "paths": {
+    "/api/CheckOrganization": {
+      "head": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "Check Organization",
+        "operationId": "checkOrganization",
+        "parameters": [
+          {
+            "name": "fiscalCode",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "vatNumber",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/connector/rest/pom.xml
+++ b/connector/rest/pom.xml
@@ -142,6 +142,37 @@
                             </configOptions>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>selfcare-onboarding-functions</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <inputSpec>${project.basedir}/docs/openapi/api-selfcare-onboarding-functions-docs.json</inputSpec>
+                            <generatorName>spring</generatorName>
+                            <library>spring-cloud</library>
+                            <modelNameSuffix />
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <configOptions>
+                                <generateForOpenFeign>true</generateForOpenFeign>
+                                <basePackage>${project.groupId}.onboarding_functions.generated.openapi.v1</basePackage>
+                                <modelPackage>${project.groupId}.onboarding_functions.generated.openapi.v1.dto</modelPackage>
+                                <apiPackage>${project.groupId}.onboarding_functions.generated.openapi.v1.api</apiPackage>
+                                <configPackage>${project.groupId}.onboarding_functions.generated.openapi.v1.config</configPackage>
+                                <additionalModelTypeAnnotations>@lombok.Builder; @lombok.NoArgsConstructor; @lombok.AllArgsConstructor</additionalModelTypeAnnotations>
+                                <dateLibrary>java8-localdatetime</dateLibrary>
+                                <delegatePattern>true</delegatePattern>
+                                <interfaceOnly>true</interfaceOnly>
+                                <annotationLibrary>none</annotationLibrary>
+                                <documentationProvider>source</documentationProvider>
+                                <openApiNullable>false</openApiNullable>
+                                <skipDefaultInterface>false</skipDefaultInterface>
+                                <useTags>true</useTags>
+                            </configOptions>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingFunctionsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingFunctionsConnectorImpl.java
@@ -17,7 +17,9 @@ public class OnboardingFunctionsConnectorImpl implements OnboardingFunctionsConn
     @Override
     public void checkOrganization(String fiscalCode, String vatNumber) {
         log.trace("checkOrganization start");
-        log.debug("checkOrganization fiscalCode = {}, vatNumber = {}", fiscalCode, vatNumber );
+        if (fiscalCode.matches("\\w*") && vatNumber.matches("\\w*")) {
+            log.debug("checkOrganization fiscalCode = {}, vatNumber = {}", fiscalCode, vatNumber );
+        }
         onboardingFunctionsApiClient._checkOrganization(fiscalCode, vatNumber);
         log.trace("checkOrganization end");
     }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingFunctionsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingFunctionsConnectorImpl.java
@@ -1,0 +1,24 @@
+package it.pagopa.selfcare.onboarding.connector;
+
+import it.pagopa.selfcare.onboarding.connector.api.OnboardingFunctionsConnector;
+import it.pagopa.selfcare.onboarding.connector.rest.client.OnboardingFunctionsApiClient;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class OnboardingFunctionsConnectorImpl implements OnboardingFunctionsConnector {
+    private final OnboardingFunctionsApiClient onboardingFunctionsApiClient;
+
+    public OnboardingFunctionsConnectorImpl(OnboardingFunctionsApiClient onboardingFunctionsApiClient) {
+        this.onboardingFunctionsApiClient = onboardingFunctionsApiClient;
+    }
+
+    @Override
+    public void checkOrganization(String fiscalCode, String vatNumber) {
+        log.trace("checkOrganization start");
+        log.debug("checkOrganization fiscalCode = {}, vatNumber = {}", fiscalCode, vatNumber );
+        onboardingFunctionsApiClient._checkOrganization(fiscalCode, vatNumber);
+        log.trace("checkOrganization end");
+    }
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/client/OnboardingFunctionsApiClient.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/client/OnboardingFunctionsApiClient.java
@@ -1,0 +1,9 @@
+package it.pagopa.selfcare.onboarding.connector.rest.client;
+
+
+import it.pagopa.selfcare.onboarding_functions.generated.openapi.v1.api.OrganizationApi;
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(name = "${rest-client.onboarding-functions-api.serviceCode}", url = "${rest-client.onboarding-functions-api.baseUrl}")
+public interface OnboardingFunctionsApiClient extends OrganizationApi {
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/config/OnboardingFunctionsClientConfig.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/config/OnboardingFunctionsClientConfig.java
@@ -1,0 +1,15 @@
+package it.pagopa.selfcare.onboarding.connector.rest.config;
+
+import it.pagopa.selfcare.commons.connector.rest.config.RestClientBaseConfig;
+import it.pagopa.selfcare.onboarding.connector.rest.client.OnboardingFunctionsApiClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@Import(RestClientBaseConfig.class)
+@EnableFeignClients(clients = {OnboardingFunctionsApiClient.class})
+@PropertySource("classpath:config/onboarding-functions-rest-client.properties")
+public class OnboardingFunctionsClientConfig {
+}

--- a/connector/rest/src/main/resources/config/onboarding-functions-rest-client.properties
+++ b/connector/rest/src/main/resources/config/onboarding-functions-rest-client.properties
@@ -1,0 +1,5 @@
+rest-client.onboarding-functions-api.serviceCode=onboarding-functions-api
+rest-client.onboarding-functions-api.baseUrl=${ONBOARDING_FUNCTIONS_URL:https://localhost:8080}
+feign.client.config.onboarding-functions-api.requestInterceptors[0]=it.pagopa.selfcare.commons.connector.rest.interceptor.AuthorizationHeaderInterceptor
+feign.client.config.onboarding-functions-api.errorDecoder=it.pagopa.selfcare.onboarding.connector.rest.decoder.FeignErrorDecoder
+feign.client.config.onboarding-functions-api.defaultRequestHeaders.x-functions-key[0]=${ONBOARDING-FUNCTIONS-API-KEY:example-api-key}

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingFunctionsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingFunctionsConnectorImplTest.java
@@ -1,0 +1,36 @@
+package it.pagopa.selfcare.onboarding.connector;
+
+import it.pagopa.selfcare.onboarding.connector.rest.client.OnboardingFunctionsApiClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OnboardingFunctionsConnectorImplTest {
+
+    @InjectMocks
+    private OnboardingFunctionsConnectorImpl onboardingFunctionsConnector;
+
+    @Mock
+    private OnboardingFunctionsApiClient restClientMock;
+
+    @Test
+    void checkOrganization(){
+        //given
+        final String fiscalCode = "fiscalCode";
+        final String vatNumber = "vatNumber";
+
+        //when
+        Executable executable = () -> onboardingFunctionsConnector.checkOrganization(fiscalCode, vatNumber);
+        //then
+        assertDoesNotThrow(executable);
+        verify(restClientMock, times(1))._checkOrganization(fiscalCode, vatNumber);
+        verifyNoMoreInteractions(restClientMock);
+    }
+}

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -71,7 +71,7 @@ class InstitutionServiceImpl implements InstitutionService {
     private final PartyConnector partyConnector;
     private final ProductsConnector productsConnector;
     private final UserRegistryConnector userConnector;
-    private final MsExternalInterceptorConnector externalInterceptorConnector;
+    private final OnboardingFunctionsConnector onboardingFunctionsConnector;
     private final OnboardingValidationStrategy onboardingValidationStrategy;
     private final PartyRegistryProxyConnector partyRegistryProxyConnector;
     private final InstitutionInfoMapper institutionMapper;
@@ -80,14 +80,14 @@ class InstitutionServiceImpl implements InstitutionService {
     InstitutionServiceImpl(OnboardingMsConnector onboardingMsConnector, PartyConnector partyConnector,
                            ProductsConnector productsConnector,
                            UserRegistryConnector userConnector,
-                           MsExternalInterceptorConnector externalInterceptorConnector,
+                           OnboardingFunctionsConnector onboardingFunctionsConnector,
                            PartyRegistryProxyConnector partyRegistryProxyConnector,
                            OnboardingValidationStrategy onboardingValidationStrategy,
                            InstitutionInfoMapper institutionMapper
                            ) {
         this.onboardingMsConnector = onboardingMsConnector;
         this.partyConnector = partyConnector;
-        this.externalInterceptorConnector = externalInterceptorConnector;
+        this.onboardingFunctionsConnector = onboardingFunctionsConnector;
         this.partyRegistryProxyConnector = partyRegistryProxyConnector;
         this.productsConnector = productsConnector;
         this.userConnector = userConnector;
@@ -408,7 +408,7 @@ class InstitutionServiceImpl implements InstitutionService {
     public void checkOrganization(String productId, String fiscalCode, String vatNumber) {
         log.trace("checkOrganization start");
         log.debug("checkOrganization productId = {}, fiscalCode = {}, vatNumber = {}", productId, fiscalCode, vatNumber );
-        externalInterceptorConnector.checkOrganization(productId, fiscalCode, vatNumber);
+        onboardingFunctionsConnector.checkOrganization(fiscalCode, vatNumber);
         log.trace("checkOrganization end");
     }
 

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -65,7 +65,7 @@ class InstitutionServiceImplTest {
     private UserRegistryConnector userConnectorMock;
 
     @Mock
-    private MsExternalInterceptorConnector msExternalInterceptorConnector;
+    private OnboardingFunctionsConnector onboardingFunctionsConnector;
 
     @Mock
     private PartyRegistryProxyConnector partyRegistryProxyConnectorMock;
@@ -1225,16 +1225,15 @@ class InstitutionServiceImplTest {
     @Test
     void checkOrganization() {
         //given
-        final String productId = "productId";
         final String fiscalCode = "fiscalCode";
         final String vatNumber = "vatNumber";
 
         //when
-        Executable executable = () -> institutionService.checkOrganization(productId, fiscalCode, vatNumber);
+        Executable executable = () -> institutionService.checkOrganization(null, fiscalCode, vatNumber);
         //then
         assertDoesNotThrow(executable);
-        verify(msExternalInterceptorConnector, times(1)).checkOrganization(productId, fiscalCode, vatNumber);
-        verifyNoMoreInteractions(msExternalInterceptorConnector);
+        verify(onboardingFunctionsConnector, times(1)).checkOrganization(fiscalCode, vatNumber);
+        verifyNoMoreInteractions(onboardingFunctionsConnector);
     }
 
     @Test


### PR DESCRIPTION
#### List of Changes

Replaced external-interceptor connector with onboarding-functions connector in service for checkOrganization API

#### Motivation and Context

The checkOrganization api was created as an http azure function on ms-onboarding for phasing out functions from external interceptor. So we need to call the new endpoint

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.