### PR TITLE
[SELC-4903] feat: added env var to call onboarding-functions api

### DIFF
--- a/infra/container_apps/env/dev-pnpg/terraform.tfvars
+++ b/infra/container_apps/env/dev-pnpg/terraform.tfvars
@@ -95,7 +95,7 @@ app_settings = [
     value = "http://selc-d-pnpg-user-ms-ca"
   },
   {
-    name = "PRODUCT_STORAGE_CONTAINER"
+    name  = "PRODUCT_STORAGE_CONTAINER"
     value = "selc-d-product"
   },
   {
@@ -105,9 +105,9 @@ app_settings = [
 ]
 
 secrets_names = {
-  "USERVICE_USER_REGISTRY_API_KEY"        = "user-registry-api-key"
-  "APPLICATIONINSIGHTS_CONNECTION_STRING" = "appinsights-connection-string"
-  "JWT_TOKEN_PUBLIC_KEY"                  = "jwt-public-key"
-  "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"   = "blob-storage-product-connection-string"
-  "ONBOARDING-FUNCTIONS-API-KEY"            = "fn-onboarding-primary-key"
+  "USERVICE_USER_REGISTRY_API_KEY"         = "user-registry-api-key"
+  "APPLICATIONINSIGHTS_CONNECTION_STRING"  = "appinsights-connection-string"
+  "JWT_TOKEN_PUBLIC_KEY"                   = "jwt-public-key"
+  "BLOB_STORAGE_PRODUCT_CONNECTION_STRING" = "blob-storage-product-connection-string"
+  "ONBOARDING-FUNCTIONS-API-KEY"           = "fn-onboarding-primary-key"
 }

--- a/infra/container_apps/env/dev-pnpg/terraform.tfvars
+++ b/infra/container_apps/env/dev-pnpg/terraform.tfvars
@@ -97,6 +97,10 @@ app_settings = [
   {
     name = "PRODUCT_STORAGE_CONTAINER"
     value = "selc-d-product"
+  },
+  {
+    name  = "ONBOARDING_FUNCTIONS_URL"
+    value = "https://selc-d-pnpg-onboarding-fn.azurewebsites.net"
   }
 ]
 
@@ -105,4 +109,5 @@ secrets_names = {
   "APPLICATIONINSIGHTS_CONNECTION_STRING" = "appinsights-connection-string"
   "JWT_TOKEN_PUBLIC_KEY"                  = "jwt-public-key"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"   = "blob-storage-product-connection-string"
+  "ONBOARDING-FUNCTIONS-API-KEY"            = "fn-onboarding-primary-key"
 }

--- a/infra/container_apps/env/dev/terraform.tfvars
+++ b/infra/container_apps/env/dev/terraform.tfvars
@@ -94,11 +94,11 @@ app_settings = [
     value = "http://selc-d-user-ms-ca"
   },
   {
-    name = "PRODUCT_STORAGE_CONTAINER"
+    name  = "PRODUCT_STORAGE_CONTAINER"
     value = "selc-d-product"
   },
   {
-    name = "ONBOARDING_FUNCTIONS_URL"
+    name  = "ONBOARDING_FUNCTIONS_URL"
     value = "https://selc-d-onboarding-fn.azurewebsites.net"
   }
 ]
@@ -108,5 +108,5 @@ secrets_names = {
   "APPLICATIONINSIGHTS_CONNECTION_STRING"  = "appinsights-connection-string"
   "JWT_TOKEN_PUBLIC_KEY"                   = "jwt-public-key"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING" = "blob-storage-product-connection-string"
-  "ONBOARDING-FUNCTIONS-API-KEY"            = "fn-onboarding-primary-key"
+  "ONBOARDING-FUNCTIONS-API-KEY"           = "fn-onboarding-primary-key"
 }

--- a/infra/container_apps/env/dev/terraform.tfvars
+++ b/infra/container_apps/env/dev/terraform.tfvars
@@ -96,6 +96,10 @@ app_settings = [
   {
     name = "PRODUCT_STORAGE_CONTAINER"
     value = "selc-d-product"
+  },
+  {
+    name = "ONBOARDING_FUNCTIONS_URL"
+    value = "https://selc-d-onboarding-fn.azurewebsites.net"
   }
 ]
 
@@ -104,4 +108,5 @@ secrets_names = {
   "APPLICATIONINSIGHTS_CONNECTION_STRING"  = "appinsights-connection-string"
   "JWT_TOKEN_PUBLIC_KEY"                   = "jwt-public-key"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING" = "blob-storage-product-connection-string"
+  "ONBOARDING-FUNCTIONS-API-KEY"            = "fn-onboarding-primary-key"
 }

--- a/infra/container_apps/env/prod-pnpg/terraform.tfvars
+++ b/infra/container_apps/env/prod-pnpg/terraform.tfvars
@@ -96,11 +96,11 @@ app_settings = [
     value = "http://selc-p-pnpg-user-ms-ca"
   },
   {
-      name  = "PRODUCT_STORAGE_CONTAINER"
-      value = "selc-p-product"
+    name  = "PRODUCT_STORAGE_CONTAINER"
+    value = "selc-p-product"
   },
   {
-    name = "ONBOARDING_FUNCTIONS_URL"
+    name  = "ONBOARDING_FUNCTIONS_URL"
     value = "https://selc-p-pnpg-onboarding-fn.azurewebsites.net"
   }
 ]
@@ -110,5 +110,5 @@ secrets_names = {
   "APPLICATIONINSIGHTS_CONNECTION_STRING"  = "appinsights-connection-string"
   "JWT_TOKEN_PUBLIC_KEY"                   = "jwt-public-key"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING" = "blob-storage-product-connection-string"
-  "ONBOARDING-FUNCTIONS-API-KEY"            = "fn-onboarding-primary-key"
+  "ONBOARDING-FUNCTIONS-API-KEY"           = "fn-onboarding-primary-key"
 }

--- a/infra/container_apps/env/prod-pnpg/terraform.tfvars
+++ b/infra/container_apps/env/prod-pnpg/terraform.tfvars
@@ -98,7 +98,11 @@ app_settings = [
   {
       name  = "PRODUCT_STORAGE_CONTAINER"
       value = "selc-p-product"
-    }
+  },
+  {
+    name = "ONBOARDING_FUNCTIONS_URL"
+    value = "https://selc-p-pnpg-onboarding-fn.azurewebsites.net"
+  }
 ]
 
 secrets_names = {
@@ -106,4 +110,5 @@ secrets_names = {
   "APPLICATIONINSIGHTS_CONNECTION_STRING"  = "appinsights-connection-string"
   "JWT_TOKEN_PUBLIC_KEY"                   = "jwt-public-key"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING" = "blob-storage-product-connection-string"
+  "ONBOARDING-FUNCTIONS-API-KEY"            = "fn-onboarding-primary-key"
 }

--- a/infra/container_apps/env/prod/terraform.tfvars
+++ b/infra/container_apps/env/prod/terraform.tfvars
@@ -96,7 +96,11 @@ app_settings = [
   {
       name  = "PRODUCT_STORAGE_CONTAINER"
       value = "selc-p-product"
-    }
+  },
+  {
+    name  = "ONBOARDING_FUNCTIONS_URL"
+    value = "https://selc-p-onboarding-fn.azurewebsites.net"
+  }
 ]
 
 secrets_names = {
@@ -104,4 +108,5 @@ secrets_names = {
   "APPLICATIONINSIGHTS_CONNECTION_STRING" = "appinsights-connection-string"
   "JWT_TOKEN_PUBLIC_KEY"                  = "jwt-public-key"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"   = "blob-storage-product-connection-string"
+  "ONBOARDING-FUNCTIONS-API-KEY"            = "fn-onboarding-primary-key"
 }

--- a/infra/container_apps/env/prod/terraform.tfvars
+++ b/infra/container_apps/env/prod/terraform.tfvars
@@ -94,8 +94,8 @@ app_settings = [
     value = "http://selc-p-user-ms-ca"
   },
   {
-      name  = "PRODUCT_STORAGE_CONTAINER"
-      value = "selc-p-product"
+    name  = "PRODUCT_STORAGE_CONTAINER"
+    value = "selc-p-product"
   },
   {
     name  = "ONBOARDING_FUNCTIONS_URL"
@@ -104,9 +104,9 @@ app_settings = [
 ]
 
 secrets_names = {
-  "USERVICE_USER_REGISTRY_API_KEY"        = "user-registry-api-key"
-  "APPLICATIONINSIGHTS_CONNECTION_STRING" = "appinsights-connection-string"
-  "JWT_TOKEN_PUBLIC_KEY"                  = "jwt-public-key"
-  "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"   = "blob-storage-product-connection-string"
-  "ONBOARDING-FUNCTIONS-API-KEY"            = "fn-onboarding-primary-key"
+  "USERVICE_USER_REGISTRY_API_KEY"         = "user-registry-api-key"
+  "APPLICATIONINSIGHTS_CONNECTION_STRING"  = "appinsights-connection-string"
+  "JWT_TOKEN_PUBLIC_KEY"                   = "jwt-public-key"
+  "BLOB_STORAGE_PRODUCT_CONNECTION_STRING" = "blob-storage-product-connection-string"
+  "ONBOARDING-FUNCTIONS-API-KEY"           = "fn-onboarding-primary-key"
 }

--- a/infra/container_apps/env/uat-pnpg/terraform.tfvars
+++ b/infra/container_apps/env/uat-pnpg/terraform.tfvars
@@ -87,7 +87,11 @@ app_settings = [
   {
       name  = "PRODUCT_STORAGE_CONTAINER"
       value = "selc-u-product"
-    }
+    },
+  {
+    name = "ONBOARDING_FUNCTIONS_URL"
+    value = "https://selc-u-pnpg-onboarding-fn.azurewebsites.net"
+  }
 ]
 
 secrets_names = {
@@ -95,4 +99,5 @@ secrets_names = {
   "APPLICATIONINSIGHTS_CONNECTION_STRING" = "appinsights-connection-string"
   "JWT_TOKEN_PUBLIC_KEY"                  = "jwt-public-key"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"  = "blob-storage-product-connection-string"
+  "ONBOARDING-FUNCTIONS-API-KEY"            = "fn-onboarding-primary-key"
 }

--- a/infra/container_apps/env/uat-pnpg/terraform.tfvars
+++ b/infra/container_apps/env/uat-pnpg/terraform.tfvars
@@ -85,19 +85,19 @@ app_settings = [
     value = "http://selc-u-pnpg-user-ms-ca"
   },
   {
-      name  = "PRODUCT_STORAGE_CONTAINER"
-      value = "selc-u-product"
-    },
+    name  = "PRODUCT_STORAGE_CONTAINER"
+    value = "selc-u-product"
+  },
   {
-    name = "ONBOARDING_FUNCTIONS_URL"
+    name  = "ONBOARDING_FUNCTIONS_URL"
     value = "https://selc-u-pnpg-onboarding-fn.azurewebsites.net"
   }
 ]
 
 secrets_names = {
-  "USERVICE_USER_REGISTRY_API_KEY"        = "user-registry-api-key"
-  "APPLICATIONINSIGHTS_CONNECTION_STRING" = "appinsights-connection-string"
-  "JWT_TOKEN_PUBLIC_KEY"                  = "jwt-public-key"
-  "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"  = "blob-storage-product-connection-string"
-  "ONBOARDING-FUNCTIONS-API-KEY"            = "fn-onboarding-primary-key"
+  "USERVICE_USER_REGISTRY_API_KEY"         = "user-registry-api-key"
+  "APPLICATIONINSIGHTS_CONNECTION_STRING"  = "appinsights-connection-string"
+  "JWT_TOKEN_PUBLIC_KEY"                   = "jwt-public-key"
+  "BLOB_STORAGE_PRODUCT_CONNECTION_STRING" = "blob-storage-product-connection-string"
+  "ONBOARDING-FUNCTIONS-API-KEY"           = "fn-onboarding-primary-key"
 }

--- a/infra/container_apps/env/uat/terraform.tfvars
+++ b/infra/container_apps/env/uat/terraform.tfvars
@@ -85,6 +85,10 @@ app_settings = [
   {
       name  = "PRODUCT_STORAGE_CONTAINER"
       value = "selc-u-product"
+  },
+  {
+    name = "ONBOARDING_FUNCTIONS_URL"
+    value = "https://selc-u-onboarding-fn.azurewebsites.net"
   }
 ]
 
@@ -93,4 +97,5 @@ secrets_names = {
   "APPLICATIONINSIGHTS_CONNECTION_STRING" = "appinsights-connection-string"
   "JWT_TOKEN_PUBLIC_KEY"                  = "jwt-public-key"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"  = "blob-storage-product-connection-string"
+  "ONBOARDING-FUNCTIONS-API-KEY"            = "fn-onboarding-primary-key"
 }

--- a/infra/container_apps/env/uat/terraform.tfvars
+++ b/infra/container_apps/env/uat/terraform.tfvars
@@ -83,19 +83,19 @@ app_settings = [
     value = "http://selc-u-user-ms-ca"
   },
   {
-      name  = "PRODUCT_STORAGE_CONTAINER"
-      value = "selc-u-product"
+    name  = "PRODUCT_STORAGE_CONTAINER"
+    value = "selc-u-product"
   },
   {
-    name = "ONBOARDING_FUNCTIONS_URL"
+    name  = "ONBOARDING_FUNCTIONS_URL"
     value = "https://selc-u-onboarding-fn.azurewebsites.net"
   }
 ]
 
 secrets_names = {
-  "USERVICE_USER_REGISTRY_API_KEY"        = "user-registry-api-key"
-  "APPLICATIONINSIGHTS_CONNECTION_STRING" = "appinsights-connection-string"
-  "JWT_TOKEN_PUBLIC_KEY"                  = "jwt-public-key"
-  "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"  = "blob-storage-product-connection-string"
-  "ONBOARDING-FUNCTIONS-API-KEY"            = "fn-onboarding-primary-key"
+  "USERVICE_USER_REGISTRY_API_KEY"         = "user-registry-api-key"
+  "APPLICATIONINSIGHTS_CONNECTION_STRING"  = "appinsights-connection-string"
+  "JWT_TOKEN_PUBLIC_KEY"                   = "jwt-public-key"
+  "BLOB_STORAGE_PRODUCT_CONNECTION_STRING" = "blob-storage-product-connection-string"
+  "ONBOARDING-FUNCTIONS-API-KEY"           = "fn-onboarding-primary-key"
 }


### PR DESCRIPTION
#### List of Changes

added env var to call onboarding-functions api

#### Motivation and Context

The checkOrganization api was created as an http azure function on ms-onboarding for phasing out functions from external interceptor. So we need to call the new endpoint

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.