### PR TITLE
[SELC-5060] feat: Added API to check manager

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2140,6 +2140,98 @@
         } ]
       }
     },
+    "/v1/users/check-manager" : {
+      "post" : {
+        "tags" : [ "user" ],
+        "summary" : "checkManager",
+        "description" : "The service allows the onboarding of Users",
+        "operationId" : "checkManager",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OnboardingUserDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "boolean"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/v1/users/onboarding" : {
       "post" : {
         "tags" : [ "user" ],

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
@@ -33,4 +33,6 @@ public interface OnboardingMsConnector {
     void onboardingPaAggregation(OnboardingData onboardingData);
 
     List<OnboardingData> getByFilters(String productId, String taxCode, String origin, String originId, String subunitCode);
+
+    boolean checkManager(OnboardingData onboardingData);
 }

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -177,6 +177,46 @@
         } ]
       }
     },
+    "/v1/onboarding/check-manager": {
+      "post": {
+        "tags": [
+          "Onboarding Controller"
+        ],
+        "summary": "In the addition administrator flow, it checks if the new manager is equal from old one, returning true ",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OnboardingUserRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authorized"
+          },
+          "403": {
+            "description": "Not Allowed"
+          }
+        },
+        "security": [
+          {
+            "SecurityScheme": []
+          }
+        ]
+      }
+    },
     "/v1/onboarding/completion" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
@@ -134,4 +134,9 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
                 .map(onboardingMapper::toOnboardingData)
                 .toList() : List.of();
     }
+
+    @Override
+    public boolean checkManager(OnboardingData onboardingData) {
+      return msOnboardingApiClient._v1OnboardingCheckManagerPost(onboardingMapper.toOnboardingUsersRequest(onboardingData)).getBody();
+    }
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
@@ -343,4 +343,26 @@ class OnboardingMsConnectorImplTest {
                 ._v1OnboardingInstitutionOnboardingsGet(origin, originId, OnboardingStatus.COMPLETED, null, null);
         verifyNoMoreInteractions(msOnboardingSupportApiClient);
     }
+
+    @Test
+    void checkManager() {
+        // given
+        final String origin = "origin";
+        final String originId = "originId";
+        OnboardingData onboardingData = new OnboardingData();
+        onboardingData.setOrigin(origin);
+        onboardingData.setOriginId(originId);
+        OnboardingUserRequest request = new OnboardingUserRequest();
+        request.setOrigin(origin);
+        request.setOriginId(originId);
+        when(msOnboardingApiClient._v1OnboardingCheckManagerPost(request))
+                .thenReturn(ResponseEntity.of(Optional.of(true)));
+        // when
+        final Executable executable = () -> onboardingMsConnector.checkManager(onboardingData);
+        // then
+        assertDoesNotThrow(executable);
+        verify(msOnboardingApiClient, times(1))
+                ._v1OnboardingCheckManagerPost(request);
+        verifyNoMoreInteractions(msOnboardingApiClient);
+    }
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/UserService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/UserService.java
@@ -6,4 +6,5 @@ import it.pagopa.selfcare.onboarding.connector.model.onboarding.User;
 public interface UserService {
     void validate(User user);
     void onboardingUsers(OnboardingData onboardingData);
+    boolean checkManager(OnboardingData onboardingData);
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/UserServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/UserServiceImpl.java
@@ -66,6 +66,15 @@ public class UserServiceImpl implements UserService {
         log.trace("onboardingUsers end");
     }
 
+    @Override
+    public boolean  checkManager(OnboardingData onboardingData) {
+        log.trace("checkManager start");
+        log.debug("checkManager onboardingData = {}", onboardingData);
+        boolean checkManager =  onboardingMsConnector.checkManager(onboardingData);
+        log.trace("checkManager end");
+        return checkManager;
+    }
+
     private <T> boolean isValid(T field, CertifiedField<T> certifiedField) {
         return certifiedField == null
                 || !Certification.isCertified(certifiedField.getCertification())

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/UserServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/UserServiceImplTest.java
@@ -154,4 +154,18 @@ class UserServiceImplTest {
         verifyNoMoreInteractions(onboardingMsConnector);
     }
 
+    @Test
+    void checkManager() {
+        // given
+        OnboardingData onboardingData = new OnboardingData();
+        when(onboardingMsConnector.checkManager(any())).thenReturn(true);
+        // when
+        userService.checkManager(onboardingData);
+        // then
+        verify(onboardingMsConnector, times(1))
+                .checkManager(onboardingData);
+        verifyNoMoreInteractions(onboardingMsConnector);
+    }
+
+
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/UserController.java
@@ -71,4 +71,21 @@ public class UserController {
         log.trace("onboarding end");
     }
 
+    @ApiResponse(responseCode = "403",
+            description = "Forbidden",
+            content = {
+                    @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE,
+                            schema = @Schema(implementation = Problem.class))
+            })
+    @PostMapping(value = "/check-manager")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "", notes = "${swagger.onboarding.users.api.onboarding}", nickname = "checkManager")
+    public Boolean checkManager(@RequestBody @Valid OnboardingUserDto request) {
+        log.trace("onboarding start");
+        log.debug("onboarding request = {}", request);
+        boolean checkManager =  userService.checkManager(onboardingResourceMapper.toEntity(request));
+        log.trace("onboarding end");
+        return checkManager;
+    }
+
 }

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/UserControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/UserControllerTest.java
@@ -5,6 +5,7 @@ import it.pagopa.selfcare.onboarding.core.UserService;
 import it.pagopa.selfcare.onboarding.core.exception.InvalidUserFieldsException;
 import it.pagopa.selfcare.onboarding.web.config.WebTestConfig;
 import it.pagopa.selfcare.onboarding.web.handler.OnboardingExceptionHandler;
+import it.pagopa.selfcare.onboarding.web.model.OnboardingUserDto;
 import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapperImpl;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -97,6 +98,24 @@ class UserControllerTest {
         // then
         verify(userServiceMock, times(1))
                 .onboardingUsers(any(OnboardingData.class));
+        verifyNoMoreInteractions(userServiceMock);
+    }
+
+    /**
+     * Method under test: {@link UserController#checkManager(OnboardingUserDto)}
+     */
+    @Test
+    void checkManager(@Value("classpath:stubs/onboardingUsers.json") Resource onboardinUserDto) throws Exception {
+        // when
+        mvc.perform(MockMvcRequestBuilders
+                        .post(BASE_URL + "/check-manager")
+                        .content(onboardinUserDto.getInputStream().readAllBytes())
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
+        // then
+        verify(userServiceMock, times(1))
+                .checkManager(any(OnboardingData.class));
         verifyNoMoreInteractions(userServiceMock);
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added API to check manager in case of USERS workflow

#### Motivation and Context

In the addition administration flow, it's necessary to check if the manager of current request is different from the previous one

#### How Has This Been Tested?

I have deployed the feature branch in dev and tested the API /onboarding/check-manager

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.