### PR TITLE
[SELC-5185] feat: Added api to retrieve products for new admin functionality

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1449,7 +1449,73 @@
         "tags" : [ "product" ],
         "summary" : "getProducts",
         "description" : "The service retrieves all products",
-        "operationId" : "getProductsUsingGET",
+        "operationId" : "getProducts",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/ProductResource"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/v1/products/admin" : {
+      "get" : {
+        "tags" : [ "product" ],
+        "summary" : "getProductsAdmin",
+        "description" : "The service retrieves all products for the addition administration functionality",
+        "operationId" : "getProductsAdmin",
         "responses" : {
           "200" : {
             "description" : "OK",

--- a/connector-api/pom.xml
+++ b/connector-api/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-product</artifactId>
-            <version>0.1.12</version>
+            <version>0.1.15</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/ProductsConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/ProductsConnector.java
@@ -11,6 +11,6 @@ public interface ProductsConnector {
 
     Product getProductValid(String id);
 
-    List<Product> getProducts();
+    List<Product> getProducts(boolean rootOnly);
 
 }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/ProductsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/ProductsConnectorImpl.java
@@ -48,8 +48,8 @@ public class ProductsConnectorImpl implements ProductsConnector {
     }
 
     @Override
-    public List<Product> getProducts() {
-        List<Product> result = productService.getProducts(false, true);
+    public List<Product> getProducts(boolean rootOnly) {
+        List<Product> result = productService.getProducts(rootOnly, true);
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "getProducts result = {}", result);
         return result;
     }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/ProductsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/ProductsConnectorImplTest.java
@@ -80,9 +80,9 @@ class ProductsConnectorImplTest {
     @Test
     void getProducts() {
         Product product = dummyProduct();
-        List<Product> products = Arrays.asList(product);
+        List<Product> products = List.of(product);
         when(productService.getProducts(anyBoolean(), anyBoolean())).thenReturn(products);
-        assertSame(products, productConnector.getProducts());
+        assertSame(products, productConnector.getProducts(true));
         verify(productService).getProducts(anyBoolean(), anyBoolean());
     }
 

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/ProductService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/ProductService.java
@@ -11,5 +11,5 @@ public interface ProductService {
 
     Product getProductValid(String id);
 
-    List<Product> getProducts();
+    List<Product> getProducts(boolean rootOnly);
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/ProductServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/ProductServiceImpl.java
@@ -45,9 +45,9 @@ public class ProductServiceImpl implements ProductService {
     }
 
     @Override
-    public List<Product> getProducts() {
+    public List<Product> getProducts(boolean rootOnly) {
         log.trace("getProducts start");
-        List<Product> products = productsConnector.getProducts();
+        List<Product> products = productsConnector.getProducts(rootOnly);
         List<Product> activeProducts = products.stream()
                 .filter(product -> ProductStatus.ACTIVE.equals(product.getStatus()))
                 .toList();

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/ProductServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/ProductServiceImplTest.java
@@ -107,9 +107,9 @@ class ProductServiceImplTest {
         product1.setStatus(ProductStatus.TESTING);
         Product product2 = new Product();
         product2.setStatus(ProductStatus.ACTIVE);
-        Mockito.when(productsConnectorMock.getProducts())
+        Mockito.when(productsConnectorMock.getProducts(true))
                 .thenReturn(List.of(product1, product2));
-        List<Product> products = productService.getProducts();
+        List<Product> products = productService.getProducts(true);
         //then
         Assertions.assertNotNull(products);
         Assertions.assertEquals(1, products.size());

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/ProductController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/ProductController.java
@@ -50,7 +50,7 @@ public class ProductController {
 
     @GetMapping(value = "/v1/products",  produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "", notes = "${swagger.onboarding.product.api.getProducts}")
+    @ApiOperation(value = "", notes = "${swagger.onboarding.product.api.getProducts}", nickname = "getProducts")
     public List<ProductResource> getProducts() {
         log.trace("getProducts start");
         final List<Product> products = productService.getProducts();
@@ -64,7 +64,7 @@ public class ProductController {
 
     @GetMapping(value = "/v1/products/admin",  produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    @ApiOperation(value = "", notes = "${swagger.onboarding.product.api.getProductsAdmin}")
+    @ApiOperation(value = "", notes = "${swagger.onboarding.product.api.getProductsAdmin}", nickname = "getProductsAdmin")
     public List<ProductResource> getProductsAdmin() {
         log.trace("getProductsAdmin start");
         final List<Product> products = productService.getProducts();

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/ProductController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/ProductController.java
@@ -15,6 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
@@ -58,6 +59,21 @@ public class ProductController {
                 .toList();
         log.debug("getProducts result = {}", resources);
         log.trace("getProducts end");
+        return resources;
+    }
+
+    @GetMapping(value = "/v1/products/admin",  produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "", notes = "${swagger.onboarding.product.api.getProductsAdmin}")
+    public List<ProductResource> getProductsAdmin() {
+        log.trace("getProductsAdmin start");
+        final List<Product> products = productService.getProducts();
+        List<ProductResource> resources = products.stream()
+                .filter(product -> Objects.nonNull(product.getUserContractTemplatePath()))
+                .map(ProductMapper::toResource)
+                .toList();
+        log.debug("getProductsAdmin result = {}", resources);
+        log.trace("getProductsAdmin end");
         return resources;
     }
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/ProductController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/ProductController.java
@@ -53,7 +53,7 @@ public class ProductController {
     @ApiOperation(value = "", notes = "${swagger.onboarding.product.api.getProducts}", nickname = "getProducts")
     public List<ProductResource> getProducts() {
         log.trace("getProducts start");
-        final List<Product> products = productService.getProducts();
+        final List<Product> products = productService.getProducts(false);
         List<ProductResource> resources = products.stream()
                 .map(ProductMapper::toResource)
                 .toList();
@@ -67,7 +67,7 @@ public class ProductController {
     @ApiOperation(value = "", notes = "${swagger.onboarding.product.api.getProductsAdmin}", nickname = "getProductsAdmin")
     public List<ProductResource> getProductsAdmin() {
         log.trace("getProductsAdmin start");
-        final List<Product> products = productService.getProducts();
+        final List<Product> products = productService.getProducts(true);
         List<ProductResource> resources = products.stream()
                 .filter(product -> Objects.nonNull(product.getUserContractTemplatePath()))
                 .map(ProductMapper::toResource)

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -70,6 +70,7 @@ swagger.onboarding.institution.model.locationData=Institution's location data, c
 swagger.onboarding.institution.model.reason=Rejection reason of an onboarding request
 swagger.onboarding.product.api.getProduct=The service retrieves the product given its internal id
 swagger.onboarding.product.api.getProducts=The service retrieves all products
+swagger.onboarding.product.api.getProductsAdmin=The service retrieves all products for the addition administration functionality
 swagger.onboarding.product.model.id=Product's unique identifier
 swagger.onboarding.product.model.title=Product's title
 swagger.onboarding.product.model.parentId=Product's parent's Id

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/ProductControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/ProductControllerTest.java
@@ -93,4 +93,32 @@ class ProductControllerTest {
                 .getProducts();
         Mockito.verifyNoMoreInteractions(productServiceMock);
     }
+
+    /**
+     * Method under test: {@link ProductController#getProductsAdmin()}
+     */
+    @Test
+    void getProductsAdmin() throws Exception {
+        //given
+        Product product = new Product();
+        product.setUserContractTemplatePath("test");
+        Mockito.when(productServiceMock.getProducts())
+                .thenReturn(List.of(product));
+        //when
+        MvcResult result = mvc.perform(MockMvcRequestBuilders
+                        .get("/v1/products/admin")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+        //then
+        List<ProductResource> response = objectMapper.readValue(
+                result.getResponse().getContentAsString(),
+                new TypeReference<>(){});
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals(1, response.size());
+        Mockito.verify(productServiceMock, Mockito.times(1))
+                .getProducts();
+        Mockito.verifyNoMoreInteractions(productServiceMock);
+    }
 }

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/ProductControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/ProductControllerTest.java
@@ -75,7 +75,7 @@ class ProductControllerTest {
     @Test
     void getProducts() throws Exception {
         //given
-        Mockito.when(productServiceMock.getProducts())
+        Mockito.when(productServiceMock.getProducts(false))
                 .thenReturn(List.of(new Product()));
         //when
         MvcResult result = mvc.perform(MockMvcRequestBuilders
@@ -90,7 +90,7 @@ class ProductControllerTest {
                 new TypeReference<>(){});
         Assertions.assertNotNull(response);
         Mockito.verify(productServiceMock, Mockito.times(1))
-                .getProducts();
+                .getProducts(false);
         Mockito.verifyNoMoreInteractions(productServiceMock);
     }
 
@@ -102,7 +102,7 @@ class ProductControllerTest {
         //given
         Product product = new Product();
         product.setUserContractTemplatePath("test");
-        Mockito.when(productServiceMock.getProducts())
+        Mockito.when(productServiceMock.getProducts(true))
                 .thenReturn(List.of(product));
         //when
         MvcResult result = mvc.perform(MockMvcRequestBuilders
@@ -118,7 +118,7 @@ class ProductControllerTest {
         Assertions.assertNotNull(response);
         Assertions.assertEquals(1, response.size());
         Mockito.verify(productServiceMock, Mockito.times(1))
-                .getProducts();
+                .getProducts(true);
         Mockito.verifyNoMoreInteractions(productServiceMock);
     }
 }


### PR DESCRIPTION
#### List of Changes

Added api to retrieve products for new admin functionality

#### Motivation and Context

This API has been added in order to separate the getAll API from the one invoked only by the addition administration flow. In this case, the service retrieves only a subset of products according to the attribute "userContractTemplatePath"

#### How Has This Been Tested?

I have deployed the feature branch in DEV

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.