### PR TITLE
[SELC-4371] fix: Added institution id into response in order to display logo

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1130,7 +1130,10 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/InstitutionResource"
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/InstitutionResource"
+                  }
                 }
               }
             }

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/InstitutionUpdate.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/InstitutionUpdate.java
@@ -16,6 +16,8 @@ public class InstitutionUpdate {
     private String address;
     private String taxCode;
     private String zipCode;
+    private String origin;
+    private String originId;
     private PaymentServiceProvider paymentServiceProvider;
     private DataProtectionOfficer dataProtectionOfficer;
     private List<GeographicTaxonomy> geographicTaxonomies;

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/InstitutionUpdate.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/InstitutionUpdate.java
@@ -9,6 +9,7 @@ import java.util.List;
 @Data
 public class InstitutionUpdate {
 
+    private String id;
     private InstitutionType institutionType;
     private String description;
     private String digitalAddress;

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/OnboardingData.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/onboarding/OnboardingData.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 @NoArgsConstructor
 public class OnboardingData {
 
+    private String id;
     private String institutionExternalId;
     private String taxCode;
     private String subunitCode;

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -1430,6 +1430,9 @@
           "origin" : {
             "$ref" : "#/components/schemas/Origin"
           },
+          "originId" : {
+            "type" : "string"
+          },
           "city" : {
             "type" : "string"
           },

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/OnboardingMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/OnboardingMapper.java
@@ -118,7 +118,13 @@ public interface OnboardingMapper {
 
     @Mapping(target = "institutionUpdate", source = "institution")
     @Mapping(target = "institutionUpdate.additionalInformations", source = "additionalInformations")
+    @Mapping(target = "institutionUpdate.origin", source = "institution.origin", qualifiedByName = "setOrigin")
     OnboardingData toOnboardingData(OnboardingResponse onboardingResponse);
+
+    @Named("setOrigin")
+    default String setOrigin(Origin origin) {
+       return Objects.nonNull(origin) ? origin.name() : null;
+    }
 
     OnboardingUserRequest toOnboardingUsersRequest(OnboardingData onboardingData);
 

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
@@ -332,6 +332,7 @@ class OnboardingMsConnectorImplTest {
         final String originId = "originId";
         final String productId = "productId";
         OnboardingResponse resource = new OnboardingResponse();
+        resource.setInstitution(new InstitutionResponse());
         resource.setProductId("productId");
         when(msOnboardingSupportApiClient._v1OnboardingInstitutionOnboardingsGet(origin, originId, OnboardingStatus.COMPLETED, null, null))
                 .thenReturn(ResponseEntity.ok(List.of(resource)));
@@ -339,6 +340,30 @@ class OnboardingMsConnectorImplTest {
         final Executable executable = () -> onboardingMsConnector.getByFilters(productId, null, origin, originId, null);
         // then
         assertDoesNotThrow(executable);
+        verify(msOnboardingSupportApiClient, times(1))
+                ._v1OnboardingInstitutionOnboardingsGet(origin, originId, OnboardingStatus.COMPLETED, null, null);
+        verifyNoMoreInteractions(msOnboardingSupportApiClient);
+    }
+
+    @Test
+    void getOnboardingByFiltersWithUO() {
+        // given
+        final String origin = "origin";
+        final String originId = "originId";
+        final String productId = "productId";
+        OnboardingResponse resource = new OnboardingResponse();
+        InstitutionResponse institution = new InstitutionResponse();
+        institution.setSubunitType(InstitutionPaSubunitType.UO);
+        resource.setInstitution(institution);
+
+        resource.setProductId("productId");
+        when(msOnboardingSupportApiClient._v1OnboardingInstitutionOnboardingsGet(origin, originId, OnboardingStatus.COMPLETED, null, null))
+                .thenReturn(ResponseEntity.ok(List.of(resource)));
+        // when
+        List<OnboardingData> result = onboardingMsConnector.getByFilters(productId, null, origin, originId, null);
+        // then
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
         verify(msOnboardingSupportApiClient, times(1))
                 ._v1OnboardingInstitutionOnboardingsGet(origin, originId, OnboardingStatus.COMPLETED, null, null);
         verifyNoMoreInteractions(msOnboardingSupportApiClient);

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
@@ -370,6 +370,30 @@ class OnboardingMsConnectorImplTest {
     }
 
     @Test
+    void getOnboardingByFiltersWithAOO() {
+        // given
+        final String origin = "origin";
+        final String originId = "originId";
+        final String productId = "productId";
+        OnboardingResponse resource = new OnboardingResponse();
+        InstitutionResponse institution = new InstitutionResponse();
+        institution.setSubunitType(InstitutionPaSubunitType.AOO);
+        resource.setInstitution(institution);
+
+        resource.setProductId("productId");
+        when(msOnboardingSupportApiClient._v1OnboardingInstitutionOnboardingsGet(origin, originId, OnboardingStatus.COMPLETED, null, null))
+                .thenReturn(ResponseEntity.ok(List.of(resource)));
+        // when
+        List<OnboardingData> result = onboardingMsConnector.getByFilters(productId, null, origin, originId, null);
+        // then
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+        verify(msOnboardingSupportApiClient, times(1))
+                ._v1OnboardingInstitutionOnboardingsGet(origin, originId, OnboardingStatus.COMPLETED, null, null);
+        verifyNoMoreInteractions(msOnboardingSupportApiClient);
+    }
+
+    @Test
     void checkManager() {
         // given
         final String origin = "origin";

--- a/connector/rest/src/test/resources/stubs/party-process/mappings/getUserInstitutionRelationships_fullyValued.json
+++ b/connector/rest/src/test/resources/stubs/party-process/mappings/getUserInstitutionRelationships_fullyValued.json
@@ -20,6 +20,8 @@
         "pricingPlan": "string",
         "institutionUpdate": {
           "id" : "id",
+          "origin": "IPA",
+          "originId": "test",
           "institutionType": "PA",
           "description": "AGENCY X",
           "digitalAddress": "email@pec.mail.org",

--- a/connector/rest/src/test/resources/stubs/party-process/mappings/getUserInstitutionRelationships_fullyValued.json
+++ b/connector/rest/src/test/resources/stubs/party-process/mappings/getUserInstitutionRelationships_fullyValued.json
@@ -19,6 +19,7 @@
         "state": "PENDING",
         "pricingPlan": "string",
         "institutionUpdate": {
+          "id" : "id",
           "institutionType": "PA",
           "description": "AGENCY X",
           "digitalAddress": "email@pec.mail.org",

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
@@ -46,5 +46,5 @@ public interface InstitutionService {
 
     InstitutionInfoIC getInstitutionsByUser(String taxCode);
 
-    Institution getByFilters(String productId, String taxCode, String origin, String originId, String subunitCode);
+    List<Institution> getByFilters(String productId, String taxCode, String origin, String originId, String subunitCode);
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -84,7 +84,7 @@ class InstitutionServiceImpl implements InstitutionService {
                            PartyRegistryProxyConnector partyRegistryProxyConnector,
                            OnboardingValidationStrategy onboardingValidationStrategy,
                            InstitutionInfoMapper institutionMapper
-                           ) {
+    ) {
         this.onboardingMsConnector = onboardingMsConnector;
         this.partyConnector = partyConnector;
         this.externalInterceptorConnector = externalInterceptorConnector;
@@ -431,15 +431,18 @@ class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
-    public Institution getByFilters(String productId, String taxCode, String origin, String originId, String subunitCode) {
+    public List<Institution> getByFilters(String productId, String taxCode, String origin, String originId, String subunitCode) {
         log.trace("getByFilters start");
         List<OnboardingData> result = onboardingMsConnector.getByFilters(productId, taxCode, origin, originId, subunitCode);
-        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getByFilters result = {}", result);
         if(Objects.isNull(result) || result.isEmpty()) {
             throw new ResourceNotFoundException();
         }
         log.trace("getByFilters end");
-        return institutionMapper.toInstitution(result.get(0).getInstitutionUpdate());
+        List<Institution> institutions = result.stream()
+                .map(OnboardingData::getInstitutionUpdate)
+                .map(institutionMapper::toInstitution).toList();
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getByFilters result = {}", institutions);
+        return institutions;
     }
 
     @Override

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/mapper/InstitutionInfoMapper.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/mapper/InstitutionInfoMapper.java
@@ -5,16 +5,16 @@ import it.pagopa.selfcare.onboarding.connector.model.institutions.InstitutionInf
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.InstitutionUpdate;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Mappings;
 
 
 @Mapper(componentModel = "spring")
 public interface InstitutionInfoMapper {
 
-    @Mappings({@Mapping(source = "city", target = "institutionLocation.city"),
-            @Mapping(source = "county", target = "institutionLocation.county"),
-            @Mapping(source = "country", target = "institutionLocation.country")})
+    @Mapping(source = "city", target = "institutionLocation.city")
+    @Mapping(source = "county", target = "institutionLocation.county")
+    @Mapping(source = "country", target = "institutionLocation.country")
     InstitutionInfo toInstitutionInfo(Institution institution);
+
 
     Institution toInstitution(InstitutionUpdate institution);
 }

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -83,8 +83,8 @@ class InstitutionServiceImplTest {
     InstitutionInfoMapper institutionInfoMapper = new InstitutionInfoMapperImpl();
 
 
-    private final static User dummyManager;
-    private final static User dummyDelegate;
+    private static final User dummyManager;
+    private static final User dummyDelegate;
 
     static {
         dummyManager = new User();

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -1175,10 +1175,10 @@ class InstitutionServiceImplTest {
         when(onboardingMsConnector.getByFilters(productId, taxCode, null, null, subunitCode))
                 .thenReturn(List.of(onboardingData));
         //when
-        Institution result = institutionService.getByFilters(productId, taxCode, null, null, subunitCode);
+        List<Institution> result = institutionService.getByFilters(productId, taxCode, null, null, subunitCode);
         //then
         assertNotNull(result);
-        assertEquals(result.getDescription(), institutionUpdate.getDescription());
+        assertEquals(result.get(0).getDescription(), institutionUpdate.getDescription());
         verify(onboardingMsConnector, times(1))
                 .getByFilters(productId, taxCode, null, null, subunitCode);
         verifyNoMoreInteractions(onboardingMsConnector);

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.commons.web.model.Problem;
-import it.pagopa.selfcare.onboarding.connector.model.institutions.Institution;
 import it.pagopa.selfcare.onboarding.core.InstitutionService;
 import it.pagopa.selfcare.onboarding.web.model.CompanyOnboardingDto;
 import it.pagopa.selfcare.onboarding.web.model.InstitutionResource;
@@ -24,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.ValidationException;
+import java.util.List;
 
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
 
@@ -90,34 +90,34 @@ public class InstitutionV2Controller {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.onboarding.subunit}", nickname = "v2GetInstitutionByFilters")
-    public InstitutionResource getInstitution(@ApiParam("${swagger.onboarding.institutions.model.productFilter}")
-                                              @RequestParam(value = "productId")
-                                              String productId,
-                                              @ApiParam("${swagger.onboarding.institutions.model.taxCode}")
-                                              @RequestParam(value = "taxCode", required = false)
-                                              String taxCode,
-                                              @ApiParam("${swagger.onboarding.institutions.model.origin}")
-                                              @RequestParam(value = "origin", required = false)
-                                              String origin,
-                                              @ApiParam("${swagger.onboarding.institutions.model.originId}")
-                                              @RequestParam(value = "originId", required = false)
-                                              String originId,
-                                              @ApiParam("${swagger.onboarding.institutions.model.subunitCode}")
-                                              @RequestParam(value = "subunitCode", required = false)
-                                              String subunitCode) {
+    public List<InstitutionResource> getInstitution(@ApiParam("${swagger.onboarding.institutions.model.productFilter}")
+                                                    @RequestParam(value = "productId")
+                                                    String productId,
+                                                    @ApiParam("${swagger.onboarding.institutions.model.taxCode}")
+                                                    @RequestParam(value = "taxCode", required = false)
+                                                    String taxCode,
+                                                    @ApiParam("${swagger.onboarding.institutions.model.origin}")
+                                                    @RequestParam(value = "origin", required = false)
+                                                    String origin,
+                                                    @ApiParam("${swagger.onboarding.institutions.model.originId}")
+                                                    @RequestParam(value = "originId", required = false)
+                                                    String originId,
+                                                    @ApiParam("${swagger.onboarding.institutions.model.subunitCode}")
+                                                    @RequestParam(value = "subunitCode", required = false)
+                                                    String subunitCode) {
         log.trace("getInstitution start");
         if (!StringUtils.hasText(taxCode) && !StringUtils.hasText(originId) && !StringUtils.hasText(origin)) {
             throw new ValidationException("At least one of taxCode, origin or originId must be present");
         } else if (StringUtils.hasText(subunitCode) && !StringUtils.hasText(taxCode)) {
             throw new ValidationException("TaxCode is required if subunitCode is present");
-        } else if (!StringUtils.hasText(subunitCode) && StringUtils.hasText(taxCode)) {
-            throw new ValidationException("SubunitCode is required if taxCode is present");
         }
-        Institution institution = institutionService.getByFilters(productId, taxCode, origin, originId, subunitCode);
-        InstitutionResource result = InstitutionMapper.toResource(institution);
-        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitution result = {}", result);
+        final List<InstitutionResource> institutions = institutionService.getByFilters(productId, taxCode, origin, originId, subunitCode)
+                .stream()
+                .map(InstitutionMapper::toResource)
+                .toList();
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "getInstitution result = {}", institutions);
         log.trace("getInstitution end");
-        return result;
+        return institutions;
     }
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
@@ -108,8 +108,6 @@ public class InstitutionV2Controller {
         log.trace("getInstitution start");
         if (!StringUtils.hasText(taxCode) && !StringUtils.hasText(originId) && !StringUtils.hasText(origin)) {
             throw new ValidationException("At least one of taxCode, origin or originId must be present");
-        } else if (StringUtils.hasText(subunitCode) && !StringUtils.hasText(taxCode)) {
-            throw new ValidationException("TaxCode is required if subunitCode is present");
         }
         final List<InstitutionResource> institutions = institutionService.getByFilters(productId, taxCode, origin, originId, subunitCode)
                 .stream()

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
@@ -18,11 +18,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import javax.validation.ValidationException;
 import java.util.List;
 
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
@@ -106,9 +104,6 @@ public class InstitutionV2Controller {
                                                     @RequestParam(value = "subunitCode", required = false)
                                                     String subunitCode) {
         log.trace("getInstitution start");
-        if (!StringUtils.hasText(taxCode) && !StringUtils.hasText(originId) && !StringUtils.hasText(origin)) {
-            throw new ValidationException("At least one of taxCode, origin or originId must be present");
-        }
         final List<InstitutionResource> institutions = institutionService.getByFilters(productId, taxCode, origin, originId, subunitCode)
                 .stream()
                 .map(InstitutionMapper::toResource)

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/InstitutionMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/InstitutionMapper.java
@@ -82,6 +82,7 @@ public class InstitutionMapper {
             resource.setTaxCode(model.getTaxCode());
             resource.setZipCode(model.getZipCode());
             resource.setOrigin(model.getOrigin());
+            resource.setId(UUID.fromString(model.getId()));
         }
         return resource;
     }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/InstitutionMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/InstitutionMapper.java
@@ -82,7 +82,6 @@ public class InstitutionMapper {
             resource.setTaxCode(model.getTaxCode());
             resource.setZipCode(model.getZipCode());
             resource.setOrigin(model.getOrigin());
-            resource.setId(UUID.fromString(model.getId()));
         }
         return resource;
     }

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2ControllerTest.java
@@ -164,20 +164,10 @@ class InstitutionV2ControllerTest {
      * Method under test: {@link InstitutionV2Controller#getInstitution(String, String, String, String, String)}
      */
     @Test
-    void getByFiltersValidationException(){
+    void getByFiltersValidationException() {
         Assertions.assertThrows(ValidationException.class,
                 () -> institutionController.getInstitution(null, null, null, null, null),
                 "At least one of taxCode, origin or originId must be present");
-    }
-
-    /**
-     * Method under test: {@link InstitutionV2Controller#getInstitution(String, String, String, String, String)}
-     */
-    @Test
-    void getByFiltersValidationExceptionTaxCodeNull(){
-        Assertions.assertThrows(ValidationException.class,
-                () -> institutionController.getInstitution(null, null, null, null, "subunitCode"),
-                "TaxCode is required if subunitCode is present");
     }
 
 }

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2ControllerTest.java
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 @WebMvcTest(value = {InstitutionV2Controller.class}, excludeAutoConfiguration = SecurityAutoConfiguration.class)
 @ContextConfiguration(classes = {InstitutionV2Controller.class, WebTestConfig.class, OnboardingResourceMapperImpl.class, OnboardingInstitutionInfoMapperImpl.class, GeographicTaxonomyMapperImpl.class})
-public class InstitutionV2ControllerTest {
+class InstitutionV2ControllerTest {
 
     private static final String BASE_URL = "/v2/institutions";
 

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2ControllerTest.java
@@ -9,7 +9,6 @@ import it.pagopa.selfcare.onboarding.web.config.WebTestConfig;
 import it.pagopa.selfcare.onboarding.web.model.mapper.GeographicTaxonomyMapperImpl;
 import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingInstitutionInfoMapperImpl;
 import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapperImpl;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +22,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import javax.validation.ValidationException;
 import java.util.List;
 import java.util.UUID;
 
@@ -158,16 +156,6 @@ class InstitutionV2ControllerTest {
                         .accept(APPLICATION_JSON_VALUE))
                 .andExpect(status().isBadRequest());
 
-    }
-
-    /**
-     * Method under test: {@link InstitutionV2Controller#getInstitution(String, String, String, String, String)}
-     */
-    @Test
-    void getByFiltersValidationException() {
-        Assertions.assertThrows(ValidationException.class,
-                () -> institutionController.getInstitution(null, null, null, null, null),
-                "At least one of taxCode, origin or originId must be present");
     }
 
 }


### PR DESCRIPTION
#### List of Changes

- Added institution id into response in order to display logo
- Changed response from single object to List
- Added filter to retrieve unique entity in case of research for only taxCode

#### Motivation and Context

In order to display logo, the API that retrieves the onboardings should contain, into institution data, an identifier of this entity
