### PR TITLE
[SELC - 5350] feat: updated verifyOnboarding invocation to OnboardingMS

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -476,15 +476,6 @@
             "type" : "string"
           }
         }, {
-          "name" : "externalId",
-          "in" : "query",
-          "description" : "Institution's unique external identifier",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
           "name" : "origin",
           "in" : "query",
           "description" : "Institution data origin",

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/OnboardingMsConnector.java
@@ -41,4 +41,6 @@ public interface OnboardingMsConnector {
     VerifyAggregateResult verifyAggregatesCsv(MultipartFile file);
 
     RecipientCodeStatusResult checkRecipientCode(String originId, String recipientCode);
+
+    void verifyOnboarding(String productId, String taxCode, String origin, String originId, String subunitCode);
 }

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -63,6 +63,60 @@
         } ]
       }
     },
+    "/v1/onboarding/verify" : {
+      "head" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "Verify if the onboarded product is already onboarded for the institution",
+        "parameters" : [ {
+          "name" : "origin",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "originId",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "productId",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "subunitCode",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "taxCode",
+          "in" : "query",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : { }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
     "/v1/aggregates/verification" : {
       "post" : {
         "tags" : [ "Aggregates Controller" ],

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
@@ -16,6 +16,7 @@ import it.pagopa.selfcare.onboarding.generated.openapi.v1.dto.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -31,6 +32,7 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
     private final MsOnboardingTokenApiClient msOnboardingTokenApiClient;
     private final MsOnboardingAggregatesApiClient msOnboardingAggregatesApiClient;
     private final OnboardingMapper onboardingMapper;
+    protected static final String REQUIRED_PRODUCT_ID_MESSAGE = "A product Id is required";
 
     public OnboardingMsConnectorImpl(MsOnboardingApiClient msOnboardingApiClient,
                                      MsOnboardingTokenApiClient msOnboardingTokenApiClient,
@@ -159,5 +161,12 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
     @Override
     public RecipientCodeStatusResult checkRecipientCode(String originId, String recipientCode) {
         return onboardingMapper.toRecipientCodeStatusResult(msOnboardingApiClient._v1OnboardingCheckRecipientCodeGet(originId, recipientCode).getBody());
+    }
+
+    public void verifyOnboarding(String productId, String taxCode, String origin, String originId, String subunitCode) {
+        log.trace("verifyOnboarding start");
+        Assert.hasText(productId, REQUIRED_PRODUCT_ID_MESSAGE);
+        msOnboardingApiClient._v1OnboardingVerifyHead(origin, originId, productId, subunitCode, taxCode);
+        log.trace("verifyOnboarding end");
     }
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImplTest.java
@@ -443,4 +443,21 @@ class OnboardingMsConnectorImplTest {
         verifyNoMoreInteractions(msOnboardingApiClient);
         verifyNoMoreInteractions(onboardingMapper);
     }
+
+    @Test
+    void verifyOnboardingSubunitCode() {
+        // given
+        final String taxCode = "taxCode";
+        final String subunitCode = "subunitCode";
+        final String productId = "productId";
+        final String origin = "origin";
+        final String originId = "originId";
+        // when
+        final Executable executable = () -> onboardingMsConnector.verifyOnboarding(productId, taxCode, origin, originId, subunitCode);
+        // then
+        assertDoesNotThrow(executable);
+        verify(msOnboardingApiClient, times(1))
+                ._v1OnboardingVerifyHead( origin, originId, productId, subunitCode, taxCode);
+        verifyNoMoreInteractions(msOnboardingApiClient);
+    }
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
@@ -40,7 +40,7 @@ public interface InstitutionService {
 
     void verifyOnboarding(String externalInstitutionId, String productId);
 
-    void verifyOnboarding(String productId, String externalId, String taxCode, String origin, String originId, String subunitCode);
+    void verifyOnboarding(String productId, String taxCode, String origin, String originId, String subunitCode);
 
     void checkOrganization(String productId, String fiscalCode, String vatNumber);
     MatchInfoResult matchInstitutionAndUser(String externalInstitutionId, User user);

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -395,11 +395,11 @@ class InstitutionServiceImpl implements InstitutionService {
 
 
     @Override
-    public void verifyOnboarding(String productId, String externalId, String taxCode, String origin, String originId, String subunitCode) {
+    public void verifyOnboarding(String productId, String taxCode, String origin, String originId, String subunitCode) {
         log.trace("verifyOnboardingSubunit start");
         log.debug("verifyOnboardingSubunit taxCode = {}", taxCode);
         validateOnboarding(taxCode, productId);
-        partyConnector.verifyOnboarding(productId, externalId, taxCode, origin, originId, subunitCode);
+        onboardingMsConnector.verifyOnboarding(productId, taxCode, origin, originId, subunitCode);
         log.trace("verifyOnboardingSubunit end");
     }
 

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -1079,18 +1079,17 @@ class InstitutionServiceImplTest {
         final String taxCode = "taxCode";
         final String subunitCode = "subunitCode";
         final String productId = "productId";
-        final String externalId = "externalId";
         final String origin = "origin";
         final String originId = "originId";
         // when
-        final Executable executable = () -> institutionService.verifyOnboarding(productId, externalId, taxCode, origin, originId, subunitCode);
+        final Executable executable = () -> institutionService.verifyOnboarding(productId, taxCode, origin, originId, subunitCode);
         // then
         final Exception e = assertThrows(OnboardingNotAllowedException.class, executable);
         assertEquals("Institution with external id '" + taxCode + "' is not allowed to onboard '" + productId + "' product", e.getMessage());
         verify(onboardingValidationStrategyMock, times(1))
                 .validate(productId, taxCode);
         verifyNoMoreInteractions(onboardingValidationStrategyMock);
-        verifyNoInteractions(productsConnectorMock, userConnectorMock, partyConnectorMock);
+        verifyNoInteractions(productsConnectorMock, userConnectorMock, onboardingMsConnector);
     }
 
     @Test
@@ -1099,20 +1098,19 @@ class InstitutionServiceImplTest {
         final String taxCode = "taxCode";
         final String subunitCode = "subunitCode";
         final String productId = "productId";
-        final String externalId = "externalId";
         final String origin = "origin";
         final String originId = "originId";
         when(onboardingValidationStrategyMock.validate(productId, taxCode))
                 .thenReturn(true);
         // when
-        final Executable executable = () -> institutionService.verifyOnboarding(productId, externalId, taxCode, origin, originId, subunitCode);
+        final Executable executable = () -> institutionService.verifyOnboarding(productId, taxCode, origin, originId, subunitCode);
         // then
         assertDoesNotThrow(executable);
         verify(onboardingValidationStrategyMock, times(1))
                 .validate(productId, taxCode);
-        verify(partyConnectorMock, times(1))
-                .verifyOnboarding(productId, externalId, taxCode, origin, originId, subunitCode);
-        verifyNoMoreInteractions(onboardingValidationStrategyMock, partyConnectorMock);
+        verify(onboardingMsConnector, times(1))
+                .verifyOnboarding(productId, taxCode, origin, originId, subunitCode);
+        verifyNoMoreInteractions(onboardingValidationStrategyMock, onboardingMsConnector);
         verifyNoInteractions(productsConnectorMock, userConnectorMock);
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionController.java
@@ -210,9 +210,6 @@ public class InstitutionController {
                                  @ApiParam("${swagger.onboarding.product.model.id}")
                                  @RequestParam("productId")
                                  String productId,
-                                 @ApiParam("${swagger.onboarding.institutions.model.externalId}")
-                                 @RequestParam(value = "externalId", required = false)
-                                 String externalId,
                                  @ApiParam("${swagger.onboarding.institutions.model.origin}")
                                  @RequestParam(value = "origin", required = false)
                                  String origin,
@@ -228,7 +225,7 @@ public class InstitutionController {
         if (VerifyType.EXTERNAL.equals(type) && vatNumber.isPresent() && (PROD_FD.getValue().equals(productId) || PROD_FD_GARANTITO.getValue().equals(productId))) {
             institutionService.checkOrganization(productId, taxCode, vatNumber.get());
         } else
-            institutionService.verifyOnboarding(productId, externalId, taxCode, origin, originId, subunitCode);
+            institutionService.verifyOnboarding(productId, taxCode, origin, originId, subunitCode);
         log.trace("verifyOnboarding end");
     }
 

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionControllerTest.java
@@ -344,14 +344,12 @@ class InstitutionControllerTest {
         String productId = "prod-fd";
         String taxCode = "taxCode";
         String subunitCode = "subunitCode";
-        String externalId = "externalId";
         String origin = "origin";
         String originId = "originId";
         //when
         mvc.perform(MockMvcRequestBuilders
                         .head(BASE_URL + "/onboarding")
                         .queryParam("productId", productId)
-                        .queryParam("externalId", externalId)
                         .queryParam("taxCode", taxCode)
                         .queryParam("origin", origin)
                         .queryParam("originId", originId)
@@ -361,7 +359,7 @@ class InstitutionControllerTest {
                         .accept(APPLICATION_JSON_VALUE))
                 .andExpect(status().isNoContent());
         //then
-        verify(institutionServiceMock, times(1)).verifyOnboarding(productId, externalId, taxCode, origin, originId, subunitCode);
+        verify(institutionServiceMock, times(1)).verifyOnboarding(productId, taxCode, origin, originId, subunitCode);
     }
     @Test
     void getInstitutionsByUserId() throws Exception {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

updated verifyOnboarding invocation to OnboardingMS

#### Motivation and Context

the invocation towards OnboardingMS has been changed instead of Core as verifyOnboarding should be the domain of the Onboarding MS

#### How Has This Been Tested?

the API was invoked locally by doing several tests. Multiple input parameters were passed looking for different types of entities for different products

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.