### PR TITLE
[SELC - 5484] feat: added check that only the productId is not passed

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1369,7 +1369,7 @@
           "style" : "form",
           "schema" : {
             "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           }
         } ],
         "requestBody" : {
@@ -1561,7 +1561,7 @@
           "style" : "form",
           "schema" : {
             "type" : "string",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           }
         } ],
         "responses" : {
@@ -3022,7 +3022,7 @@
           "institutionType" : {
             "type" : "string",
             "description" : "Institution's type",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           },
           "productId" : {
             "type" : "string",
@@ -3574,7 +3574,7 @@
           "institutionType" : {
             "type" : "string",
             "description" : "Institution's type",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           },
           "isAggregator" : {
             "type" : "boolean",
@@ -3674,7 +3674,7 @@
           "institutionType" : {
             "type" : "string",
             "description" : "Institution's type",
-            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PRV", "PSP", "PT", "REC", "SA", "SCP" ]
           },
           "origin" : {
             "type" : "string",

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -1114,6 +1114,10 @@ class InstitutionServiceImplTest {
     static Stream<Arguments> provideParametersNotAllowed() {
         return Stream.of(
                 Arguments.of("", "", "", ""),
+                Arguments.of(null, "", "", ""),
+                Arguments.of("", null, "", ""),
+                Arguments.of("", "", null, ""),
+                Arguments.of("", "", "", null),
                 Arguments.of(null, null, null, null)
         );
     }

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -1122,6 +1122,37 @@ class InstitutionServiceImplTest {
         );
     }
 
+    @ParameterizedTest
+    @MethodSource("provideParametersAllowed")
+    void verifyOnboardingInfo_allowedParameter(String taxCode, String origin, String originId, String subunitCode) {
+        // given
+        final String productId = "productId";
+        when(onboardingValidationStrategyMock.validate(productId, taxCode))
+                .thenReturn(true);
+
+        // when
+        final Executable executable = () -> institutionService.verifyOnboarding(productId, taxCode, originId, origin, subunitCode);
+
+        // then
+        assertDoesNotThrow(executable);
+        verify(onboardingValidationStrategyMock, times(1))
+                .validate(productId, taxCode);
+        verify(onboardingMsConnector, times(1))
+                .verifyOnboarding(productId, taxCode, originId, origin, subunitCode);
+        verifyNoMoreInteractions(onboardingValidationStrategyMock, onboardingMsConnector);
+        verifyNoInteractions(productsConnectorMock, userConnectorMock);
+    }
+
+    static Stream<Arguments> provideParametersAllowed() {
+        return Stream.of(
+                Arguments.of("taxCode", "", "", ""),
+                Arguments.of("", "origin", "", ""),
+                Arguments.of("", "", "originId", ""),
+                Arguments.of("", "", "", "subunitCode")
+
+        );
+    }
+
     @Test
     void verifyOnboardingInfo_allowed() {
         // given


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

added check that only the productId is not passed

#### Motivation and Context

To prevent the frontend from passing only the productId as a parameter for verifyOnboarding and returning 204, a control has been added so that 400 is returned

#### How Has This Been Tested?

the microservice was started locally and only the productId was passed in order to verify that a 400 was returned instead of 204

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.