### PR TITLE
[PNPG-224] feat: added check on infocamere to prevent user which is not LR to onboard the PG

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
@@ -20,7 +20,7 @@ public interface InstitutionService {
 
     void onboardingProductV2(OnboardingData onboardingData);
 
-    void onboardingCompanyV2(OnboardingData onboardingData);
+    void onboardingCompanyV2(OnboardingData onboardingData, String userFiscalCode);
 
     void onboardingProduct(OnboardingData onboardingData);
 

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -118,11 +118,23 @@ class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
-    public void onboardingCompanyV2(OnboardingData onboardingData) {
+    public void onboardingCompanyV2(OnboardingData onboardingData, String userFiscalCode) {
         log.trace("onboardingProductAsync start");
         log.debug("onboardingProductAsync onboardingData = {}", onboardingData);
+        InstitutionInfoIC userBusinesses = partyRegistryProxyConnector.getInstitutionsByUserFiscalCode(userFiscalCode);
+        if(businessIsNotRelatedToUser(userBusinesses, onboardingData.getTaxCode())){
+            throw new OnboardingNotAllowedException("The selected business does not belong to the user");
+        }
         onboardingMsConnector.onboardingCompany(onboardingData);
         log.trace("onboarding end");
+    }
+
+    private boolean businessIsNotRelatedToUser(InstitutionInfoIC institutionInfoIC, String businessTaxCode) {
+        return institutionInfoIC == null
+                || CollectionUtils.isEmpty(institutionInfoIC.getBusinesses())
+                || institutionInfoIC.getBusinesses()
+                .stream()
+                .noneMatch(business -> business.getBusinessTaxId().equals(businessTaxCode));
     }
 
     @Override

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -154,9 +154,10 @@ class InstitutionServiceImplTest {
         onboardingData.setOrigin(Origin.INFOCAMERE.getValue());
         onboardingData.setInstitutionType(InstitutionType.PG);
         onboardingData.setUsers(List.of(dummyManager, dummyDelegate));
+        String managerTaxCode = dummyManager.getTaxCode();
 
         InstitutionInfoIC institutionInfoIC = new InstitutionInfoIC();
-        institutionInfoIC.setLegalTaxId(dummyManager.getTaxCode());
+        institutionInfoIC.setLegalTaxId(managerTaxCode);
         BusinessInfoIC businessInfoIC = new BusinessInfoIC();
         businessInfoIC.setBusinessName("businessName");
         businessInfoIC.setBusinessTaxId(onboardingData.getTaxCode());
@@ -165,12 +166,12 @@ class InstitutionServiceImplTest {
         when(partyRegistryProxyConnectorMock.getInstitutionsByUserFiscalCode(anyString()))
                 .thenReturn(institutionInfoIC);
         // when
-        institutionService.onboardingCompanyV2(onboardingData, dummyManager.getTaxCode());
+        institutionService.onboardingCompanyV2(onboardingData, managerTaxCode);
         // then
         verify(partyRegistryProxyConnectorMock, times(1))
-                .getInstitutionsByUserFiscalCode(dummyManager.getTaxCode());
+                .getInstitutionsByUserFiscalCode(managerTaxCode);
         verify(partyRegistryProxyConnectorMock, times(0))
-                .matchInstitutionAndUser(onboardingData.getTaxCode(), dummyManager.getTaxCode());
+                .matchInstitutionAndUser(onboardingData.getTaxCode(), managerTaxCode);
         verify(onboardingMsConnector, times(1))
                 .onboardingCompany(any());
     }
@@ -182,18 +183,19 @@ class InstitutionServiceImplTest {
         onboardingData.setOrigin(Origin.ADE.getValue());
         onboardingData.setInstitutionType(InstitutionType.PG);
         onboardingData.setUsers(List.of(dummyManager, dummyDelegate));
+        String managerTaxCode = dummyManager.getTaxCode();
 
         MatchInfoResult matchInfoResult = new MatchInfoResult();
         matchInfoResult.setVerificationResult(true);
-        when(partyRegistryProxyConnectorMock.matchInstitutionAndUser(onboardingData.getTaxCode(), dummyManager.getTaxCode()))
+        when(partyRegistryProxyConnectorMock.matchInstitutionAndUser(onboardingData.getTaxCode(), managerTaxCode))
                 .thenReturn(matchInfoResult);
         // when
-        institutionService.onboardingCompanyV2(onboardingData, dummyManager.getTaxCode());
+        institutionService.onboardingCompanyV2(onboardingData, managerTaxCode);
         // then
         verify(partyRegistryProxyConnectorMock, times(0))
-                .getInstitutionsByUserFiscalCode(dummyManager.getTaxCode());
+                .getInstitutionsByUserFiscalCode(managerTaxCode);
         verify(partyRegistryProxyConnectorMock, times(1))
-                .matchInstitutionAndUser(onboardingData.getTaxCode(), dummyManager.getTaxCode());
+                .matchInstitutionAndUser(onboardingData.getTaxCode(), managerTaxCode);
         verify(onboardingMsConnector, times(1))
                 .onboardingCompany(any());
     }
@@ -205,16 +207,17 @@ class InstitutionServiceImplTest {
         onboardingData.setOrigin(Origin.INFOCAMERE.getValue());
         onboardingData.setInstitutionType(InstitutionType.PG);
         onboardingData.setUsers(List.of(dummyManager, dummyDelegate));
+        String managerTaxCode = dummyManager.getTaxCode();
 
-        when(partyRegistryProxyConnectorMock.getInstitutionsByUserFiscalCode(dummyManager.getTaxCode()))
+        when(partyRegistryProxyConnectorMock.getInstitutionsByUserFiscalCode(managerTaxCode))
                 .thenReturn(new InstitutionInfoIC());
         // when
-        Assertions.assertThrows(OnboardingNotAllowedException.class, () -> institutionService.onboardingCompanyV2(onboardingData, dummyManager.getTaxCode()));
+        Assertions.assertThrows(OnboardingNotAllowedException.class, () -> institutionService.onboardingCompanyV2(onboardingData, managerTaxCode));
         // then
         verify(partyRegistryProxyConnectorMock, times(1))
-                .getInstitutionsByUserFiscalCode(dummyManager.getTaxCode());
+                .getInstitutionsByUserFiscalCode(managerTaxCode);
         verify(partyRegistryProxyConnectorMock, times(0))
-                .matchInstitutionAndUser(onboardingData.getTaxCode(), dummyManager.getTaxCode());
+                .matchInstitutionAndUser(onboardingData.getTaxCode(), managerTaxCode);
         verify(onboardingMsConnector, times(0))
                 .onboardingCompany(any());
     }
@@ -226,16 +229,17 @@ class InstitutionServiceImplTest {
         onboardingData.setOrigin(Origin.ADE.getValue());
         onboardingData.setInstitutionType(InstitutionType.PG);
         onboardingData.setUsers(List.of(dummyManager, dummyDelegate));
+        String managerTaxCode = dummyManager.getTaxCode();
 
-        when(partyRegistryProxyConnectorMock.matchInstitutionAndUser(onboardingData.getTaxCode(), dummyManager.getTaxCode()))
+        when(partyRegistryProxyConnectorMock.matchInstitutionAndUser(onboardingData.getTaxCode(), managerTaxCode))
                 .thenReturn(new MatchInfoResult());
         // when
-        Assertions.assertThrows(OnboardingNotAllowedException.class, () -> institutionService.onboardingCompanyV2(onboardingData, dummyManager.getTaxCode()));
+        Assertions.assertThrows(OnboardingNotAllowedException.class, () -> institutionService.onboardingCompanyV2(onboardingData, managerTaxCode));
         // then
         verify(partyRegistryProxyConnectorMock, times(0))
-                .getInstitutionsByUserFiscalCode(dummyManager.getTaxCode());
+                .getInstitutionsByUserFiscalCode(managerTaxCode);
         verify(partyRegistryProxyConnectorMock, times(1))
-                .matchInstitutionAndUser(onboardingData.getTaxCode(), dummyManager.getTaxCode());
+                .matchInstitutionAndUser(onboardingData.getTaxCode(), managerTaxCode);
         verify(onboardingMsConnector, times(0))
                 .onboardingCompany(any());
     }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
@@ -15,6 +15,7 @@ import it.pagopa.selfcare.onboarding.web.model.*;
 import it.pagopa.selfcare.onboarding.web.model.mapper.InstitutionMapper;
 import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.owasp.encoder.Encode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -76,7 +77,7 @@ public class InstitutionV2Controller {
     @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.onboarding.subunit}")
     public void onboarding(@RequestBody @Valid CompanyOnboardingDto request, Principal principal) {
         log.trace(ONBOARDING_START);
-        log.debug("onboarding request = {}", request);
+        log.debug("onboarding request = {}", Encode.forJava(request.toString()));
         JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) principal;
         SelfCareUser selfCareUser = (SelfCareUser) jwtAuthenticationToken.getPrincipal();
         institutionService.onboardingCompanyV2(onboardingResourceMapper.toEntity(request), selfCareUser.getFiscalCode());

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
@@ -7,7 +7,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
+import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.commons.web.model.Problem;
+import it.pagopa.selfcare.commons.web.security.JwtAuthenticationToken;
 import it.pagopa.selfcare.onboarding.core.InstitutionService;
 import it.pagopa.selfcare.onboarding.web.model.*;
 import it.pagopa.selfcare.onboarding.web.model.mapper.InstitutionMapper;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
+import java.security.Principal;
 import java.util.List;
 
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
@@ -71,10 +74,12 @@ public class InstitutionV2Controller {
     @PostMapping(value = "/company/onboarding")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.onboarding.subunit}")
-    public void onboarding(@RequestBody @Valid CompanyOnboardingDto request) {
+    public void onboarding(@RequestBody @Valid CompanyOnboardingDto request, Principal principal) {
         log.trace(ONBOARDING_START);
         log.debug("onboarding request = {}", request);
-        institutionService.onboardingCompanyV2(onboardingResourceMapper.toEntity(request));
+        JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) principal;
+        SelfCareUser selfCareUser = (SelfCareUser) jwtAuthenticationToken.getPrincipal();
+        institutionService.onboardingCompanyV2(onboardingResourceMapper.toEntity(request), selfCareUser.getFiscalCode());
         log.trace(ONBOARDING_END);
     }
 

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2ControllerTest.java
@@ -2,7 +2,9 @@ package it.pagopa.selfcare.onboarding.web.controller;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.commons.base.utils.ProductId;
+import it.pagopa.selfcare.commons.web.security.JwtAuthenticationToken;
 import it.pagopa.selfcare.onboarding.connector.model.institutions.Institution;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
 import it.pagopa.selfcare.onboarding.core.InstitutionService;
@@ -12,6 +14,7 @@ import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingInstitutionInfoM
 import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapperImpl;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
@@ -97,10 +100,16 @@ class InstitutionV2ControllerTest {
 
     @Test
     void onboardingCompany(@Value("classpath:stubs/onboardingCompanyDto.json") Resource onboardingDto) throws Exception {
-
+        //given
+        JwtAuthenticationToken mockPrincipal = Mockito.mock(JwtAuthenticationToken.class);
+        SelfCareUser selfCareUser = SelfCareUser.builder("example")
+                .fiscalCode("fiscalCode")
+                .build();
+        Mockito.when(mockPrincipal.getPrincipal()).thenReturn(selfCareUser);
         // when
         mvc.perform(MockMvcRequestBuilders
                         .post(BASE_URL + "/company/onboarding")
+                        .principal(mockPrincipal)
                         .content(onboardingDto.getInputStream().readAllBytes())
                         .contentType(APPLICATION_JSON_VALUE)
                         .accept(APPLICATION_JSON_VALUE))
@@ -109,7 +118,7 @@ class InstitutionV2ControllerTest {
         // then
 
         verify(institutionServiceMock, times(1))
-                .onboardingCompanyV2(any(OnboardingData.class));
+                .onboardingCompanyV2(any(OnboardingData.class), anyString());
         verifyNoMoreInteractions(institutionServiceMock);
     }
 


### PR DESCRIPTION
#### List of Changes

added check on infocamere to prevent user which is not LR to onboard the PG

#### Motivation and Context

Without this feature, any user invoking the API could onboard the business even if is not Manager on Infocamere. Because actually the check is present only on frontend.

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.