### PR TITLE
fix: add skip_provider_registration true

### DIFF
--- a/infra/container_apps/main.tf
+++ b/infra/container_apps/main.tf
@@ -6,6 +6,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  skip_provider_registration = true
 }
 
 module "container_app_onboarding_backend" {


### PR DESCRIPTION
#### List of Changes

Fix of this https://pagopa.atlassian.net/wiki/spaces/DEVOPS/pages/463241875/Terraform+Troubleshooting+FAQs#%5CuD83E%5CuDD14-Problem%3A-Error-ensuring-Resource-Providers-are-registered.

#### Motivation and Context

#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.