### PR TITLE
[SELC-5668] Feat: added vatNumber in VerifyAggregatesResponse.aggregates

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1191,6 +1191,15 @@
         "summary" : "onboarding",
         "description" : "The service allows the onboarding of Users to a subunit of an Institution",
         "operationId" : "onboardingUsingPOST_2",
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -3267,6 +3276,9 @@
             "items" : {
               "$ref" : "#/components/schemas/User"
             }
+          },
+          "vatNumber" : {
+            "type" : "string"
           },
           "zipCode" : {
             "type" : "string"

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/institutions/Institution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/institutions/Institution.java
@@ -15,6 +15,7 @@ public class Institution {
     private String id;
     private String externalId;
     private String originId;
+    private String vatNumber;
     private String description;
     private String parentDescription;
     private String digitalAddress;

--- a/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
+++ b/connector/rest/docs/openapi/api-selfcare-onboarding-docs.json
@@ -29,6 +29,8 @@
       "post" : {
         "tags" : [ "Aggregates Controller" ],
         "summary" : "Validate the data related to the aggregated entities present in a CSV file",
+        "description" : "Validates aggregated entity data specific to the PROD-IO environment by processing the provided CSV file. This ensures that all entries meet the required criteria before further processing.",
+        "operationId" : "verifyAppIoAggregatesCsv",
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
@@ -51,7 +53,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/VerifyAggregateResponse"
+                  "$ref" : "#/components/schemas/VerifyAggregateAppIoResponse"
                 }
               }
             }
@@ -72,6 +74,8 @@
       "post" : {
         "tags" : [ "Aggregates Controller" ],
         "summary" : "Validate the data related to the aggregated entities present in a CSV file",
+        "description" : "Validates aggregated entity data specific to the PROD-Pagopa environment by processing the provided CSV file. This ensures that all entries meet the required criteria before further processing.",
+        "operationId" : "verifyPagoPaAggregatesCsv",
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
@@ -115,6 +119,8 @@
       "post" : {
         "tags" : [ "Aggregates Controller" ],
         "summary" : "Validate the data related to the aggregated entities present in a CSV file",
+        "description" : "Validates aggregated entity data specific to the PROD-PN environment by processing the provided CSV file. This ensures that all entries meet the required criteria before further processing.",
+        "operationId" : "verifySendAggregatesCsv",
         "requestBody" : {
           "content" : {
             "multipart/form-data" : {
@@ -158,6 +164,8 @@
       "post" : {
         "tags" : [ "Notification Controller" ],
         "summary" : "Resend onboarding notifications for onboarding which are retrieved given a set of filters",
+        "description" : "Resends notifications for all onboarding records that match the specified filter criteria. This allows administrators to trigger notification processes again for specific onboardings based on parameters such as product ID, tax code, institution ID, and more.",
+        "operationId" : "resendOnboardingNotifications",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -193,7 +201,9 @@
     "/v1/onboarding" : {
       "get" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "The API retrieves paged onboarding using optional filter, order by descending creation date",
+        "summary" : "Retrieve paged onboardings with optional filters and sorting.",
+        "description" : "The API retrieves paged onboarding using optional filter, order by descending creation date",
+        "operationId" : "getOnboardingWithFilter",
         "parameters" : [ {
           "name" : "from",
           "in" : "query",
@@ -283,7 +293,9 @@
       },
       "post" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform default onboarding request, it is used for GSP/SA/AS institution type.Users data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding based on institution type.",
+        "summary" : "Default onboarding for GSP/SA/AS institutions, saves user data, and triggers async onboarding activities.",
+        "description" : "Perform default onboarding request, it is used for GSP/SA/AS institution type.Users data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding based on institution type.",
+        "operationId" : "onboarding",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -319,7 +331,9 @@
     "/v1/onboarding/aggregation/completion" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform onboarding aggregation as /onboarding but completing the onboarding request to COMPLETED phase. The operation will be performed async due to the possible amount of time the process could take.",
+        "summary" : "Asynchronously complete aggregated onboarding to COMPLETED status.",
+        "description" : "Perform onboarding aggregation as /onboarding but completing the onboarding request to COMPLETED phase. The operation will be performed async due to the possible amount of time the process could take.",
+        "operationId" : "onboardingAggregationCompletion",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -352,10 +366,50 @@
         } ]
       }
     },
+    "/v1/onboarding/aggregation/increment" : {
+      "post" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "Perform Increment for aggregates",
+        "description" : "Perform the increment of the aggregates for an aggregator entity that has already completed the initial onboarding.The API initiates the onboarding process for the aggregated entities received as input.",
+        "operationId" : "onboardingAggregationIncrement",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OnboardingPaRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OnboardingResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
     "/v1/onboarding/check-manager" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "In the addition administrator flow, it checks if the new manager is equal from old one, returning true ",
+        "summary" : "Check if new manager matches the current manager.",
+        "description" : "In the addition administrator flow, it checks if the new manager is equal from old one, returning true ",
+        "operationId" : "checkManager",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -391,7 +445,9 @@
     "/v1/onboarding/checkRecipientCode" : {
       "get" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "check if recipientCode is valid or not",
+        "summary" : "Validate recipientCode.",
+        "description" : "check if recipientCode is valid or not",
+        "operationId" : "checkRecipientCode",
         "parameters" : [ {
           "name" : "originId",
           "in" : "query",
@@ -431,7 +487,9 @@
     "/v1/onboarding/completion" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform onboarding as /onboarding but completing the onboarding request to COMPLETED phase.",
+        "summary" : "Complete onboarding request and set status to COMPLETED.",
+        "description" : "Perform onboarding as /onboarding but completing the onboarding request to COMPLETED phase.",
+        "operationId" : "onboardingCompletion",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -467,7 +525,8 @@
     "/v1/onboarding/institutionOnboardings" : {
       "get" : {
         "tags" : [ "support", "Onboarding" ],
-        "summary" : "Returns onboardings record by institution taxCode/subunitCode/origin/originId",
+        "summary" : "Get onboardings by institution taxCode, subunitCode, origin, or originId.",
+        "description" : "Returns onboardings record by institution taxCode/subunitCode/origin/originId",
         "operationId" : "onboardingInstitutionUsingGET",
         "parameters" : [ {
           "name" : "origin",
@@ -529,7 +588,9 @@
     "/v1/onboarding/pa" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform onboarding request for PA institution type, it require billing.recipientCode in additition to default requestUsers data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding that consist of create contract and sending mail to institution's digital address.",
+        "summary" : "Onboarding for PA institutions with billing.recipientCode, saves user data, creates contracts, and sends emails.",
+        "description" : "Perform onboarding request for PA institution type, it require billing.recipientCode in addition to default requestUsers data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding that consist of create contract and sending mail to institution's digital address.",
+        "operationId" : "onboardingPa",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -565,7 +626,9 @@
     "/v1/onboarding/pa/aggregation" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform onboarding aggregation request for PA institution type, it require billing.recipientCode in additition to default requestUsers data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding aggregation that consist of create contract and sending mail to institution's digital address.",
+        "summary" : "Aggregated onboarding for PA institutions, saves user data, creates contracts, and sends emails.",
+        "description" : "Perform onboarding aggregation request for PA institution type, it require billing.recipientCode in addition to default requestUsers data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding aggregation that consist of create contract and sending mail to institution's digital address.",
+        "operationId" : "onboardingPaAggregation",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -601,7 +664,9 @@
     "/v1/onboarding/pa/completion" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform onboarding as /onboarding/pa but completing the onboarding request to COMPLETED phase.",
+        "summary" : "Complete PA onboarding request and set status to COMPLETED.",
+        "description" : "Perform onboarding as /onboarding/pa but completing the onboarding request to COMPLETED phase.",
+        "operationId" : "onboardingPaCompletion",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -637,7 +702,9 @@
     "/v1/onboarding/pa/import" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform onboarding as /onboarding/pa but create token and completing the onboarding request to COMPLETED phase.",
+        "summary" : "Import PA onboarding with token creation and complete to COMPLETED.",
+        "description" : "Perform onboarding as /onboarding/pa but create token and completing the onboarding request to COMPLETED phase.",
+        "operationId" : "onboardingPaImport",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -673,6 +740,9 @@
     "/v1/onboarding/pg/completion" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
+        "summary" : "Complete PG onboarding request on PNPG domain and set status to COMPLETED.",
+        "description" : "Perform onboarding as /onboarding/psp but completing the onboarding request to COMPLETED phase.",
+        "operationId" : "onboardingPgCompletion",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -708,7 +778,9 @@
     "/v1/onboarding/psp" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform onboarding request for PSP institution type.Users data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding that consist of sending mail to Selfcare admin for approve request.",
+        "summary" : "Onboarding for PSP institutions, saves user data, and requests admin approval via email.",
+        "description" : "Perform onboarding request for PSP institution type.Users data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding that consist of sending mail to Selfcare admin for approve request.",
+        "operationId" : "onboardingPsp",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -744,7 +816,9 @@
     "/v1/onboarding/psp/completion" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform onboarding as /onboarding/psp but completing the onboarding request to COMPLETED phase.",
+        "summary" : "Complete PSP onboarding request and set status to COMPLETED.",
+        "description" : "Perform onboarding as /onboarding/psp but completing the onboarding request to COMPLETED phase.",
+        "operationId" : "onboardingPspCompletion",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -780,7 +854,9 @@
     "/v1/onboarding/users" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform onboarding users request, it is used all institution types.Users data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding based on institution type.",
+        "summary" : "Onboard users for all institution types, save user data, and trigger async onboarding activities.",
+        "description" : "Perform onboarding users request, it is used all institution types.Users data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding based on institution type.",
+        "operationId" : "onboardingUsers",
         "requestBody" : {
           "content" : {
             "application/json" : {
@@ -816,7 +892,9 @@
     "/v1/onboarding/verify" : {
       "head" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Verify if the onboarded product is already onboarded for the institution",
+        "summary" : "Check if product is already onboarded for the institution.",
+        "description" : "Verify if the onboarded product is already onboarded for the institution",
+        "operationId" : "verifyOnboardingInfoByFilters",
         "parameters" : [ {
           "name" : "origin",
           "in" : "query",
@@ -870,7 +948,9 @@
     "/v1/onboarding/{onboardingId}" : {
       "get" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Retrieve an onboarding record given its ID",
+        "summary" : "Get onboarding record by ID.",
+        "description" : "Retrieve an onboarding record given its ID",
+        "operationId" : "getById",
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",
@@ -905,7 +985,9 @@
     "/v1/onboarding/{onboardingId}/approve" : {
       "put" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform approve operation of an onboarding request receiving onboarding id.Function triggers async activities related to onboarding based on institution type or completing onboarding. ",
+        "summary" : "Approve onboarding request and trigger async activities.",
+        "description" : "Perform approve operation of an onboarding request receiving onboarding id.Function triggers async activities related to onboarding based on institution type or completing onboarding.",
+        "operationId" : "approve",
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",
@@ -936,7 +1018,8 @@
     "/v1/onboarding/{onboardingId}/complete" : {
       "put" : {
         "tags" : [ "internal-v1" ],
-        "summary" : "Perform complete operation of an onboarding request receiving onboarding id and contract signed by the institution.It checks the contract's signature and upload the contract on an azure storageAt the end, function triggers async activities related to complete onboarding that consist of create the institution, activate the onboarding and sending data to notification queue.",
+        "summary" : "Complete onboarding by verifying and uploading contract, then trigger async activities.",
+        "description" : "Perform complete operation of an onboarding request receiving onboarding id and contract signed by the institution.It checks the contract's signature and upload the contract on an azure storageAt the end, function triggers async activities related to complete onboarding that consist of create the institution, activate the onboarding and sending data to notification queue.",
         "operationId" : "completeOnboardingUsingPUT",
         "parameters" : [ {
           "name" : "onboardingId",
@@ -984,7 +1067,9 @@
     "/v1/onboarding/{onboardingId}/completeOnboardingUsers" : {
       "put" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform complete operation of an user onboarding request receiving onboarding id and contract signed by the institution.It checks the contract's signature and upload the contract on an azure storageAt the end, function triggers async activities related to complete onboarding that consist of create the institution, activate the onboarding and sending data to notification queue.",
+        "summary" : "Complete user onboarding by verifying and uploading contract, then trigger async activities.",
+        "description" : "Perform complete operation of an user onboarding request receiving onboarding id and contract signed by the institution.It checks the contract's signature and upload the contract on an azure storageAt the end, function triggers async activities related to complete onboarding that consist of create the institution, activate the onboarding and sending data to notification queue.",
+        "operationId" : "completeOnboardingUser",
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",
@@ -1030,8 +1115,9 @@
     },
     "/v1/onboarding/{onboardingId}/consume" : {
       "put" : {
-        "tags" : [ "support", "internal-v1", "Onboarding"],
-        "summary" : "Perform complete operation of an onboarding request as /complete but without signature verification of the contract",
+        "tags" : [ "support", "internal-v1", "Onboarding" ],
+        "summary" : "Complete onboarding without verifying contract signature.",
+        "description" : "Perform complete operation of an onboarding request as /complete but without signature verification of the contract",
         "operationId" : "completeOnboardingTokenConsume",
         "parameters" : [ {
           "name" : "onboardingId",
@@ -1079,7 +1165,9 @@
     "/v1/onboarding/{onboardingId}/pending" : {
       "get" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Returns an onboarding record by its ID only if its status is PENDING. This feature is crucial for ensuring that the onboarding process can be completed only when the onboarding status is appropriately set to PENDING.",
+        "summary" : "Get pending onboarding by ID.",
+        "description" : "Returns an onboarding record by its ID only if its status is PENDING. This feature is crucial for ensuring that the onboarding process can be completed only when the onboarding status is appropriately set to PENDING.",
+        "operationId" : "getOnboardingPending",
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",
@@ -1114,7 +1202,9 @@
     "/v1/onboarding/{onboardingId}/reject" : {
       "put" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Perform reject operation of an onboarding request receiving onboarding id.Function change status to REJECT for an onboarding request that is not COMPLETED. ",
+        "summary" : "Perform reject operation of an onboarding request",
+        "description" : "Perform reject operation of an onboarding request receiving onboarding id.Function change status to REJECT for an onboarding request that is not COMPLETED. ",
+        "operationId" : "delete",
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",
@@ -1154,7 +1244,8 @@
     "/v1/onboarding/{onboardingId}/update" : {
       "put" : {
         "tags" : [ "support", "Onboarding" ],
-        "summary" : "Update onboarding request receiving onboarding id.Function can change some values. ",
+        "summary" : "Update onboarding request with new values.",
+        "description" : "Update onboarding request receiving onboarding id.Function can change some values.",
         "operationId" : "updateOnboardiUsingPUT",
         "parameters" : [ {
           "name" : "onboardingId",
@@ -1201,7 +1292,9 @@
     "/v1/onboarding/{onboardingId}/withUserInfo" : {
       "get" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Retrieve an onboarding record given its ID adding to user sensitive information",
+        "summary" : "Get onboarding record by ID with user sensitive info.",
+        "description" : "Retrieve an onboarding record given its ID adding to user sensitive information",
+        "operationId" : "getByIdWithUserInfo",
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",
@@ -1237,6 +1330,8 @@
       "get" : {
         "tags" : [ "Token Controller" ],
         "summary" : "Retrieves the token for a given onboarding",
+        "description" : "Fetches a list of tokens associated with the specified onboarding ID.",
+        "operationId" : "getToken",
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "query",
@@ -1274,6 +1369,8 @@
       "get" : {
         "tags" : [ "Token Controller" ],
         "summary" : "Retrieve contract not signed for a given onboarding",
+        "description" : "Downloads the unsigned contract file associated with the specified onboarding ID.",
+        "operationId" : "getContract",
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",
@@ -1341,6 +1438,38 @@
           }
         }
       },
+      "AggregateAppIo" : {
+        "type" : "object",
+        "properties" : {
+          "subunitCode" : {
+            "type" : "string"
+          },
+          "subunitType" : {
+            "$ref" : "#/components/schemas/InstitutionPaSubunitType"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "digitalAddress" : {
+            "type" : "string"
+          },
+          "taxCode" : {
+            "type" : "string"
+          },
+          "vatNumber" : {
+            "type" : "string"
+          },
+          "address" : {
+            "type" : "string"
+          },
+          "originId" : {
+            "type" : "string"
+          },
+          "origin" : {
+            "type" : "string"
+          }
+        }
+      },
       "AggregateInstitutionRequest" : {
         "required" : [ "taxCode", "description" ],
         "type" : "object",
@@ -1355,6 +1484,9 @@
             "type" : "string"
           },
           "subunitType" : {
+            "type" : "string"
+          },
+          "vatNumber" : {
             "type" : "string"
           },
           "geographicTaxonomies" : {
@@ -2483,6 +2615,23 @@
           },
           "productRole" : {
             "type" : "string"
+          }
+        }
+      },
+      "VerifyAggregateAppIoResponse" : {
+        "type" : "object",
+        "properties" : {
+          "aggregates" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AggregateAppIo"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/RowError"
+            }
           }
         }
       },

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/OnboardingMsConnectorImpl.java
@@ -57,11 +57,11 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
     @Retry(name = "retryTimeout")
     public void onboarding(OnboardingData onboardingData) {
         if (onboardingData.getInstitutionType() == InstitutionType.PA) {
-            msOnboardingApiClient._v1OnboardingPaPost(onboardingMapper.toOnboardingPaRequest(onboardingData));
+            msOnboardingApiClient._onboardingPa(onboardingMapper.toOnboardingPaRequest(onboardingData));
         } else if (onboardingData.getInstitutionType() == InstitutionType.PSP) {
-            msOnboardingApiClient._v1OnboardingPspPost(onboardingMapper.toOnboardingPspRequest(onboardingData));
+            msOnboardingApiClient._onboardingPsp(onboardingMapper.toOnboardingPspRequest(onboardingData));
         } else {
-            msOnboardingApiClient._v1OnboardingPost(onboardingMapper.toOnboardingDefaultRequest(onboardingData));
+            msOnboardingApiClient._onboarding(onboardingMapper.toOnboardingDefaultRequest(onboardingData));
         }
     }
 
@@ -70,13 +70,13 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
         log.info("validateAggregatesCsv for product: {}", productId);
         switch (productId) {
             case PROD_IO -> {
-                return onboardingMapper.toVerifyAggregateResult(msOnboardingAggregatesApiClient._v1AggregatesVerificationProdIoPost(file).getBody());
+                return onboardingMapper.toVerifyAggregateAppIoResult(msOnboardingAggregatesApiClient._verifyAppIoAggregatesCsv(file).getBody());
             }
             case PROD_PAGOPA -> {
-                return onboardingMapper.toVerifyAggregateResult(msOnboardingAggregatesApiClient._v1AggregatesVerificationProdPagopaPost(file).getBody());
+                return onboardingMapper.toVerifyAggregatePagoPaResult(msOnboardingAggregatesApiClient._verifyPagoPaAggregatesCsv(file).getBody());
             }
             case PROD_PN -> {
-                return onboardingMapper.toVerifyAggregateSendResponse(msOnboardingAggregatesApiClient._v1AggregatesVerificationProdPnPost(file).getBody());
+                return onboardingMapper.toVerifyAggregateSendResponse(msOnboardingAggregatesApiClient._verifySendAggregatesCsv(file).getBody());
             }
             default -> {
                 log.error("Unsupported productId: {}", productId);
@@ -88,14 +88,14 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
     @Override
     @Retry(name = "retryTimeout")
     public void onboardingUsers(OnboardingData onboardingData) {
-        msOnboardingApiClient._v1OnboardingUsersPost(onboardingMapper.toOnboardingUsersRequest(onboardingData));
+        msOnboardingApiClient._onboardingUsers(onboardingMapper.toOnboardingUsersRequest(onboardingData));
     }
 
 
     @Override
     @Retry(name = "retryTimeout")
     public void onboardingCompany(OnboardingData onboardingData) {
-        msOnboardingApiClient._v1OnboardingPgCompletionPost(onboardingMapper.toOnboardingPgRequest(onboardingData));
+        msOnboardingApiClient._onboardingPgCompletion(onboardingMapper.toOnboardingPgRequest(onboardingData));
     }
 
     @Override
@@ -107,19 +107,19 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
     @Override
     @Retry(name = "retryTimeout")
     public void onboardingUsersComplete(String onboardingId, MultipartFile contract) {
-        msOnboardingApiClient._v1OnboardingOnboardingIdCompleteOnboardingUsersPut(onboardingId, contract);
+        msOnboardingApiClient._completeOnboardingUser(onboardingId, contract);
     }
 
     @Override
     @Retry(name = "retryTimeout")
     public void onboardingPending(String onboardingId) {
-        msOnboardingApiClient._v1OnboardingOnboardingIdPendingGet(onboardingId);
+        msOnboardingApiClient._getOnboardingPending(onboardingId);
     }
 
     @Override
     @Retry(name = "retryTimeout")
     public void approveOnboarding(String onboardingId) {
-        msOnboardingApiClient._v1OnboardingOnboardingIdApprovePut(onboardingId);
+        msOnboardingApiClient._approve(onboardingId);
     }
 
     @Override
@@ -129,33 +129,33 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
         if(StringUtils.hasText(reason)) {
             reasonForReject.setReasonForReject(reason);
         }
-        msOnboardingApiClient._v1OnboardingOnboardingIdRejectPut(onboardingId, reasonForReject);
+        msOnboardingApiClient._delete(onboardingId, reasonForReject);
     }
 
     @Override
     @Retry(name = "retryTimeout")
     public OnboardingData getOnboarding(String onboardingId) {
-        OnboardingGet onboardingGet = msOnboardingApiClient._v1OnboardingOnboardingIdGet(onboardingId).getBody();
+        OnboardingGet onboardingGet = msOnboardingApiClient._getById(onboardingId).getBody();
         return onboardingMapper.toOnboardingData(onboardingGet);
     }
 
     @Override
     @Retry(name = "retryTimeout")
     public OnboardingData getOnboardingWithUserInfo(String onboardingId) {
-        OnboardingGet onboardingGet = msOnboardingApiClient._v1OnboardingOnboardingIdWithUserInfoGet(onboardingId).getBody();
+        OnboardingGet onboardingGet = msOnboardingApiClient._getByIdWithUserInfo(onboardingId).getBody();
         return onboardingMapper.toOnboardingData(onboardingGet);
     }
 
     @Override
     @Retry(name = "retryTimeout")
     public Resource getContract(String onboardingId) {
-        return msOnboardingTokenApiClient._v1TokensOnboardingIdContractGet(onboardingId).getBody();
+        return msOnboardingTokenApiClient._getContract(onboardingId).getBody();
     }
 
     @Override
     @Retry(name = "retryTimeout")
     public void onboardingPaAggregation(OnboardingData onboardingData) {
-        msOnboardingApiClient._v1OnboardingPaAggregationPost(onboardingMapper.toOnboardingPaAggregationRequest(onboardingData));
+        msOnboardingApiClient._onboardingPaAggregation(onboardingMapper.toOnboardingPaAggregationRequest(onboardingData));
     }
 
     @Override
@@ -177,19 +177,19 @@ public class OnboardingMsConnectorImpl implements OnboardingMsConnector {
 
     @Override
     public boolean checkManager(OnboardingData onboardingData) {
-        return Boolean.TRUE.equals(Objects.requireNonNull(msOnboardingApiClient._v1OnboardingCheckManagerPost(onboardingMapper.toOnboardingUsersRequest(onboardingData)))
+        return Boolean.TRUE.equals(Objects.requireNonNull(msOnboardingApiClient._checkManager(onboardingMapper.toOnboardingUsersRequest(onboardingData)))
                 .getBody());
     }
 
     @Override
     public RecipientCodeStatusResult checkRecipientCode(String originId, String recipientCode) {
-        return onboardingMapper.toRecipientCodeStatusResult(msOnboardingApiClient._v1OnboardingCheckRecipientCodeGet(originId, recipientCode).getBody());
+        return onboardingMapper.toRecipientCodeStatusResult(msOnboardingApiClient._checkRecipientCode(originId, recipientCode).getBody());
     }
 
     public void verifyOnboarding(String productId, String taxCode, String origin, String originId, String subunitCode) {
         log.trace("verifyOnboarding start");
         Assert.hasText(productId, REQUIRED_PRODUCT_ID_MESSAGE);
-        msOnboardingApiClient._v1OnboardingVerifyHead(origin, originId, productId, subunitCode, taxCode);
+        msOnboardingApiClient._verifyOnboardingInfoByFilters(origin, originId, productId, subunitCode, taxCode);
         log.trace("verifyOnboarding end");
     }
 }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/OnboardingMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/OnboardingMapper.java
@@ -133,7 +133,9 @@ public interface OnboardingMapper {
     @Mapping(target = "institution", source = ".", qualifiedByName = "toInstitutionBase")
     OnboardingPaRequest toOnboardingPaAggregationRequest(OnboardingData onboardingData);
 
-    VerifyAggregateResult toVerifyAggregateResult(VerifyAggregateResponse body);
+    VerifyAggregateResult toVerifyAggregateAppIoResult(VerifyAggregateAppIoResponse body);
+
+    VerifyAggregateResult toVerifyAggregatePagoPaResult(VerifyAggregateResponse body);
 
     VerifyAggregateResult toVerifyAggregateSendResponse(VerifyAggregateSendResponse body);
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Updated selfcare onboarding openapi and related API
- Added vatNumber in VerifyAggregatesResponse.aggregates
<!--- Describe your changes in detail -->

#### Motivation and Context
For the contract of the aggregating entities, it is necessary to include all the data of the aggregated entities, both those retrieved from IPA and those sent via CSV and not overwritten by IPA. Therefore, it is essential that all this data is available during the initial persistence.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.