### PR TITLE
[PNPG-263] feat: added dedicate response object for check-manager API

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2673,10 +2673,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "type" : "object",
-                  "additionalProperties" : {
-                    "type" : "boolean"
-                  }
+                  "$ref" : "#/components/schemas/CheckManagerResponse"
                 }
               }
             }
@@ -3400,6 +3397,18 @@
           "businessTaxId" : {
             "type" : "string",
             "description" : "Legal Representative's institutions tax ID"
+          }
+        }
+      },
+      "CheckManagerResponse" : {
+        "title" : "CheckManagerResponse",
+        "required" : [ "response" ],
+        "type" : "object",
+        "properties" : {
+          "response" : {
+            "type" : "boolean",
+            "description" : "Is the given user manager of the institution",
+            "example" : false
           }
         }
       },

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/UserController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.commons.web.model.Problem;
 import it.pagopa.selfcare.onboarding.core.UserService;
+import it.pagopa.selfcare.onboarding.web.model.CheckManagerResponse;
 import it.pagopa.selfcare.onboarding.web.model.OnboardingUserDto;
 import it.pagopa.selfcare.onboarding.web.model.UserDataValidationDto;
 import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapper;
@@ -20,8 +21,6 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.Collections;
-import java.util.Map;
 
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
 
@@ -100,11 +99,11 @@ public class UserController {
     @PostMapping(value = "/check-manager")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.onboarding.users.api.check-manager}", nickname = "checkManager")
-    public Map<String, Boolean> checkManager(@RequestBody @Valid OnboardingUserDto request) {
+    public CheckManagerResponse checkManager(@RequestBody @Valid OnboardingUserDto request) {
         log.trace("onboarding start");
         boolean checkManager =  userService.checkManager(onboardingResourceMapper.toEntity(request));
         log.trace("onboarding end");
-        return Collections.singletonMap("result", checkManager);
+        return new CheckManagerResponse(checkManager);
     }
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/CheckManagerResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/CheckManagerResponse.java
@@ -1,0 +1,16 @@
+package it.pagopa.selfcare.onboarding.web.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+@Data
+public class CheckManagerResponse {
+    @ApiModelProperty(value = "${swagger.user.check-manager.model.response}", required = true)
+    @JsonProperty(required = true)
+    private boolean response;
+
+    public CheckManagerResponse(boolean response) {
+        this.response = response;
+    }
+}

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -158,4 +158,5 @@ swagger.onboarding.institutions.model.additionalInformations.otherNote=Other not
 swagger.onboarding.institutions.model.aggregates=List of Aggregate Institutions, not empty only if isAggregator field's value is True
 swagger.onboarding.institutions.model.isAggregator=specified if given institution is an Aggregator
 
+swagger.user.check-manager.model.response=Is the given user manager of the institution
 


### PR DESCRIPTION
#### List of Changes

added dedicate response object for check-manager API

#### Motivation and Context

Previously the API had a response formed by a map, but it created problems for frontend codegens. So we created a dedicated object.

#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.