### PR TITLE
[SELC-6113] feat: Added api /company/verify-legal to check if user is manager of given company on external registries

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1279,6 +1279,88 @@
         } ]
       }
     },
+    "/v2/institutions/company/verify-manager" : {
+      "post" : {
+        "tags" : [ "institutions" ],
+        "summary" : "verifyManager",
+        "description" : "The service allows to verify the legal representative on external registries and retrieve the company name",
+        "operationId" : "verifyManagerUsingPOST",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/VerifyManagerRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/VerifyManagerResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/v2/institutions/onboarding" : {
       "post" : {
         "tags" : [ "institutions" ],
@@ -4543,6 +4625,34 @@
             "items" : {
               "$ref" : "#/components/schemas/RowErrorResponse"
             }
+          }
+        }
+      },
+      "VerifyManagerRequest" : {
+        "title" : "VerifyManagerRequest",
+        "type" : "object",
+        "properties" : {
+          "companyTaxCode" : {
+            "type" : "string",
+            "description" : "Institution's taxCode"
+          },
+          "userTaxCode" : {
+            "type" : "string",
+            "description" : "User's fiscal code"
+          }
+        }
+      },
+      "VerifyManagerResponse" : {
+        "title" : "VerifyManagerResponse",
+        "type" : "object",
+        "properties" : {
+          "companyName" : {
+            "type" : "string",
+            "description" : "Institution's legal name"
+          },
+          "origin" : {
+            "type" : "string",
+            "description" : "Institution data origin"
           }
         }
       }

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/institutions/ManagerVerification.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/institutions/ManagerVerification.java
@@ -1,0 +1,17 @@
+package it.pagopa.selfcare.onboarding.connector.model.institutions;
+
+import lombok.Data;
+
+@Data
+public class ManagerVerification {
+    private String origin;
+    private String companyName;
+
+    public ManagerVerification() {
+    }
+
+    public ManagerVerification(String origin, String companyName) {
+        this.origin = origin;
+        this.companyName = companyName;
+    }
+}

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/institutions/ManagerVerification.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/model/institutions/ManagerVerification.java
@@ -1,17 +1,13 @@
 package it.pagopa.selfcare.onboarding.connector.model.institutions;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class ManagerVerification {
     private String origin;
     private String companyName;
-
-    public ManagerVerification() {
-    }
-
-    public ManagerVerification(String origin, String companyName) {
-        this.origin = origin;
-        this.companyName = companyName;
-    }
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionService.java
@@ -3,10 +3,7 @@ package it.pagopa.selfcare.onboarding.core;
 import it.pagopa.selfcare.onboarding.connector.model.InstitutionLegalAddressData;
 import it.pagopa.selfcare.onboarding.connector.model.InstitutionOnboardingData;
 import it.pagopa.selfcare.onboarding.connector.model.RecipientCodeStatusResult;
-import it.pagopa.selfcare.onboarding.connector.model.institutions.Institution;
-import it.pagopa.selfcare.onboarding.connector.model.institutions.InstitutionInfo;
-import it.pagopa.selfcare.onboarding.connector.model.institutions.MatchInfoResult;
-import it.pagopa.selfcare.onboarding.connector.model.institutions.VerifyAggregateResult;
+import it.pagopa.selfcare.onboarding.connector.model.institutions.*;
 import it.pagopa.selfcare.onboarding.connector.model.institutions.infocamere.InstitutionInfoIC;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.GeographicTaxonomy;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
@@ -58,4 +55,6 @@ public interface InstitutionService {
     RecipientCodeStatusResult checkRecipientCode(String originId, String recipientCode);
 
     void onboardingUsersPgFromIcAndAde(OnboardingData onboardingUserPgRequest);
+
+    ManagerVerification verifyManager(String taxCode, String companyTaxCode);
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -630,7 +630,7 @@ class InstitutionServiceImpl implements InstitutionService {
 
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "Checking if user with taxCode {} is manager of institution with taxCode {} on INFOCAMERE", Encode.forJava(userTaxCode), Encode.forJava(institutionTaxCode));
         InstitutionInfoIC institutionInfoIC = partyRegistryProxyConnector.getInstitutionsByUserFiscalCode(userTaxCode);
-        if (Objects.nonNull(institutionInfoIC) && !CollectionUtils.isEmpty(institutionInfoIC.getBusinesses())) {
+        if (Objects.nonNull(institutionInfoIC) && Objects.nonNull(institutionInfoIC.getBusinesses())){
             for (BusinessInfoIC business : institutionInfoIC.getBusinesses()) {
                 if (institutionTaxCode.equals(business.getBusinessTaxId())) {
                     log.debug("User found as manager in INFOCAMERE for business with name = {}", business.getBusinessName());

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImpl.java
@@ -627,9 +627,8 @@ class InstitutionServiceImpl implements InstitutionService {
     @Override
     public ManagerVerification verifyManager(String userTaxCode, String institutionTaxCode) {
         log.trace("verifyManager start");
-        log.debug("verifyManager userTaxCode = {}, institutionTaxCode = {}", Encode.forJava(userTaxCode), Encode.forJava(institutionTaxCode));
 
-        log.debug(LogUtils.CONFIDENTIAL_MARKER, "Checking if user with taxCode {} is manager of institution with taxCode {} on INFOCAMERE", userTaxCode, institutionTaxCode);
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "Checking if user with taxCode {} is manager of institution with taxCode {} on INFOCAMERE", Encode.forJava(userTaxCode), Encode.forJava(institutionTaxCode));
         InstitutionInfoIC institutionInfoIC = partyRegistryProxyConnector.getInstitutionsByUserFiscalCode(userTaxCode);
         if (Objects.nonNull(institutionInfoIC) && !CollectionUtils.isEmpty(institutionInfoIC.getBusinesses())) {
             for (BusinessInfoIC business : institutionInfoIC.getBusinesses()) {
@@ -641,7 +640,7 @@ class InstitutionServiceImpl implements InstitutionService {
         }
 
         try {
-            log.debug(LogUtils.CONFIDENTIAL_MARKER, "Checking if user with taxCode {} is manager of institution with taxCode {} on ADE", userTaxCode, institutionTaxCode);
+            log.debug(LogUtils.CONFIDENTIAL_MARKER, "Checking if user with taxCode {} is manager of institution with taxCode {} on ADE", Encode.forJava(userTaxCode), Encode.forJava(institutionTaxCode));
             MatchInfoResult matchInfoResult = partyRegistryProxyConnector.matchInstitutionAndUser(institutionTaxCode, userTaxCode);
             if (Objects.nonNull(matchInfoResult) && matchInfoResult.isVerificationResult()) {
                 log.debug("User found as manager in ADE, response = {}", matchInfoResult);

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -1086,8 +1086,6 @@ class InstitutionServiceImplTest {
         // given
         String taxCode = "validTaxCode";
         String companyTaxCode = "validCompanyTaxCode";
-        InstitutionInfoIC institutionInfoIC = new InstitutionInfoIC();
-        institutionInfoIC.setBusinesses(Collections.emptyList());
 
         when(partyRegistryProxyConnectorMock.getInstitutionsByUserFiscalCode(anyString())).thenReturn(null);
         when(partyRegistryProxyConnectorMock.matchInstitutionAndUser(anyString(), anyString())).thenReturn(null);

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -1332,7 +1332,7 @@ class InstitutionServiceImplTest {
         final Executable executable = () -> institutionService.verifyOnboarding(productId, taxCode, originId, origin, subunitCode);
 
         // then
-        final Exception e = assertThrows(InvalidRequestException.class, executable);
+        assertThrows(InvalidRequestException.class, executable);
         verifyNoInteractions(productsConnectorMock, userConnectorMock, onboardingMsConnector);
     }
 
@@ -2097,7 +2097,7 @@ class InstitutionServiceImplTest {
         RecipientCodeStatusResult result = institutionService.checkRecipientCode("recipientCode", "originId");
 
         // Then
-        assertEquals(result, RecipientCodeStatusResult.ACCEPTED);
+        assertEquals(RecipientCodeStatusResult.ACCEPTED, result);
         verify(onboardingMsConnector, times(1)).checkRecipientCode(any(), any());
         verifyNoMoreInteractions(onboardingMsConnector);
     }

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/InstitutionServiceImplTest.java
@@ -1004,6 +1004,129 @@ class InstitutionServiceImplTest {
     }
 
     @Test
+    void verifyManager_userIsManagerOnInfocamere() {
+        // given
+        String taxCode = "validTaxCode";
+        String companyTaxCode = "validCompanyTaxCode";
+        InstitutionInfoIC institutionInfoIC = new InstitutionInfoIC();
+        BusinessInfoIC businessInfoIC = new BusinessInfoIC();
+        businessInfoIC.setBusinessTaxId("otherCompanyTaxCode");
+        businessInfoIC.setBusinessName("CompanyName 2");
+        BusinessInfoIC businessInfoIC2 = new BusinessInfoIC();
+        businessInfoIC2.setBusinessTaxId(companyTaxCode);
+        businessInfoIC2.setBusinessName("CompanyName 1");
+        institutionInfoIC.setBusinesses(List.of(businessInfoIC, businessInfoIC2));
+        when(partyRegistryProxyConnectorMock.getInstitutionsByUserFiscalCode(taxCode)).thenReturn(institutionInfoIC);
+
+        // when
+        ManagerVerification result = institutionService.verifyManager(taxCode, companyTaxCode);
+
+        // then
+        assertNotNull(result);
+        assertEquals(Origin.INFOCAMERE.getValue(), result.getOrigin());
+        assertEquals("CompanyName 1", result.getCompanyName());
+    }
+
+    @Test
+    void verifyManager_userIsManagerOnAde() {
+        // given
+        String taxCode = "validTaxCode";
+        String companyTaxCode = "validCompanyTaxCode";
+        InstitutionInfoIC institutionInfoIC = new InstitutionInfoIC();
+        institutionInfoIC.setBusinesses(Collections.emptyList());
+        when(partyRegistryProxyConnectorMock.getInstitutionsByUserFiscalCode(taxCode)).thenReturn(institutionInfoIC);
+        MatchInfoResult matchInfoResult = new MatchInfoResult();
+        matchInfoResult.setVerificationResult(true);
+        when(partyRegistryProxyConnectorMock.matchInstitutionAndUser(companyTaxCode, taxCode)).thenReturn(matchInfoResult);
+
+        // when
+        ManagerVerification result = institutionService.verifyManager(taxCode, companyTaxCode);
+
+        // then
+        assertNotNull(result);
+        assertEquals(Origin.ADE.getValue(), result.getOrigin());
+    }
+
+    @Test
+    void verifyManager_userAdeIsNull() {
+        // given
+        String taxCode = "validTaxCode";
+        String companyTaxCode = "validCompanyTaxCode";
+
+        //when
+        InstitutionInfoIC institutionInfoIC = new InstitutionInfoIC();
+        institutionInfoIC.setBusinesses(Collections.emptyList());
+        when(partyRegistryProxyConnectorMock.getInstitutionsByUserFiscalCode(taxCode)).thenReturn(institutionInfoIC);
+        when(partyRegistryProxyConnectorMock.matchInstitutionAndUser(companyTaxCode, taxCode)).thenReturn(null);
+
+        // then
+        assertThrows(ResourceNotFoundException.class, () -> institutionService.verifyManager(taxCode, companyTaxCode));
+    }
+
+    @Test
+    void verifyManager_userAdeIsFalse() {
+        // given
+        String taxCode = "validTaxCode";
+        String companyTaxCode = "validCompanyTaxCode";
+
+        //when
+        InstitutionInfoIC institutionInfoIC = new InstitutionInfoIC();
+        institutionInfoIC.setBusinesses(Collections.emptyList());
+        when(partyRegistryProxyConnectorMock.getInstitutionsByUserFiscalCode(taxCode)).thenReturn(institutionInfoIC);
+        MatchInfoResult matchInfoResult = new MatchInfoResult();
+        matchInfoResult.setVerificationResult(false);
+        when(partyRegistryProxyConnectorMock.matchInstitutionAndUser(companyTaxCode, taxCode)).thenReturn(matchInfoResult);
+
+        // then
+        assertThrows(ResourceNotFoundException.class, () -> institutionService.verifyManager(taxCode, companyTaxCode));
+    }
+
+    @Test
+    void verifyManager_businessNull() {
+        // given
+        String taxCode = "validTaxCode";
+        String companyTaxCode = "validCompanyTaxCode";
+        InstitutionInfoIC institutionInfoIC = new InstitutionInfoIC();
+        institutionInfoIC.setBusinesses(Collections.emptyList());
+
+        when(partyRegistryProxyConnectorMock.getInstitutionsByUserFiscalCode(anyString())).thenReturn(null);
+        when(partyRegistryProxyConnectorMock.matchInstitutionAndUser(anyString(), anyString())).thenReturn(null);
+
+        // when & then
+        assertThrows(ResourceNotFoundException.class, () -> institutionService.verifyManager(taxCode, companyTaxCode));
+    }
+
+    @Test
+    void verifyManager_noBusinessFound() {
+        // given
+        String taxCode = "validTaxCode";
+        String companyTaxCode = "validCompanyTaxCode";
+        InstitutionInfoIC institutionInfoIC = new InstitutionInfoIC();
+        institutionInfoIC.setBusinesses(Collections.emptyList());
+
+        when(partyRegistryProxyConnectorMock.getInstitutionsByUserFiscalCode(anyString())).thenReturn(institutionInfoIC);
+        when(partyRegistryProxyConnectorMock.matchInstitutionAndUser(anyString(), anyString())).thenReturn(null);
+
+        // when & then
+        assertThrows(ResourceNotFoundException.class, () -> institutionService.verifyManager(taxCode, companyTaxCode));
+    }
+
+    @Test
+    void verifyManager_invalidRequestException() {
+        // given
+        String taxCode = "validTaxCode";
+        String companyTaxCode = "validCompanyTaxCode";
+        InstitutionInfoIC institutionInfoIC = new InstitutionInfoIC();
+        institutionInfoIC.setBusinesses(Collections.emptyList());
+
+        when(partyRegistryProxyConnectorMock.getInstitutionsByUserFiscalCode(anyString())).thenReturn(institutionInfoIC);
+        when(partyRegistryProxyConnectorMock.matchInstitutionAndUser(anyString(), anyString())).thenThrow(new InvalidRequestException("Invalid request"));
+
+        // when & then
+        assertThrows(ResourceNotFoundException.class, () -> institutionService.verifyManager(taxCode, companyTaxCode));
+    }
+
+    @Test
     void getInstitutions() {
         //given
         InstitutionInfo expectedInstitutionInfo = new InstitutionInfo();

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/InstitutionV2Controller.java
@@ -133,6 +133,16 @@ public class InstitutionV2Controller {
         return response;
     }
 
+    @PostMapping(value = "/company/verify-manager")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.onboarding.verifyManager}")
+    public VerifyManagerResponse verifyManager(@RequestBody @Valid VerifyManagerRequest request) {
+        log.trace("verifyManager start");
+        VerifyManagerResponse response = onboardingResourceMapper.toManagerVerification(institutionService.verifyManager(request.getUserTaxCode(), request.getCompanyTaxCode()));
+        log.trace("verifyManager end");
+        return response;
+    }
+
     @GetMapping(value = "/onboarding/active")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.onboarding.institutions.api.onboarding.getActiveOnboarding}")

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/VerifyManagerRequest.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/VerifyManagerRequest.java
@@ -1,0 +1,20 @@
+package it.pagopa.selfcare.onboarding.web.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+public class VerifyManagerRequest {
+    @ApiModelProperty(value = "${swagger.onboarding.user.model.fiscalCode}")
+    @JsonProperty(required = true)
+    @NotBlank
+    private String userTaxCode;
+
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.taxCode}")
+    @JsonProperty(required = true)
+    @NotBlank
+    private String companyTaxCode;
+}

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/VerifyManagerResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/VerifyManagerResponse.java
@@ -1,0 +1,13 @@
+package it.pagopa.selfcare.onboarding.web.model;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+@Data
+public class VerifyManagerResponse {
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.origin}")
+    private String origin;
+
+    @ApiModelProperty(value = "${swagger.onboarding.institutions.model.name}")
+    private String companyName;
+}

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/OnboardingResourceMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/OnboardingResourceMapper.java
@@ -4,6 +4,7 @@ import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.onboarding.connector.model.InstitutionLegalAddressData;
 import it.pagopa.selfcare.onboarding.connector.model.RecipientCodeStatusResult;
 import it.pagopa.selfcare.onboarding.connector.model.institutions.Institution;
+import it.pagopa.selfcare.onboarding.connector.model.institutions.ManagerVerification;
 import it.pagopa.selfcare.onboarding.connector.model.institutions.VerifyAggregateResult;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.InstitutionOnboarding;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
@@ -37,6 +38,8 @@ public interface OnboardingResourceMapper {
     @Mapping(source = "gpuData", target = "institutionUpdate.gpuData")
     @Mapping(source = "originId", target = "originId")
     OnboardingData toEntity(OnboardingProductDto dto);
+
+    VerifyManagerResponse toManagerVerification(ManagerVerification managerVerification);
 
     Institution toInstitution(AggregateInstitution aggregateInstitution);
 

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -8,6 +8,7 @@ swagger.onboarding.institutions.api.onboarding.getActiveOnboarding=The service r
 swagger.onboarding.institutions.api.onboarding=The service allows the onboarding of Users to an Institution
 swagger.onboarding.institutions.api.onboarding.subunit=The service allows the onboarding of Users to a subunit of an Institution
 swagger.onboarding.institutions.api.onboarding.verifyAggregatesCsv=The service allows to verify if the given csv contains valid aggregate institutions
+swagger.onboarding.institutions.api.onboarding.verifyManager= The service allows to verify the legal representative on external registries and retrieve the company name
 swagger.onboarding.institutions.api.onboarding.checkRecipientCode=The service allows to verify if recipientCode is valid or not
 swagger.onboarding.institutions.api.onboardingUsersPg=The service allows the onboarding of Users to a PG Institution
 swagger.onboarding.institutions.api.getInstitutionOnboardingInfo=The service retrieves the institutions Manager and institution informations


### PR DESCRIPTION
#### List of Changes

Added api /company/verify-legal to check if user is manager of given company on external registries

#### Motivation and Context

With this API, it is possible to check whether a user is a legal representative on the records of infocamere and ADE. It returns 404 if the verification fails

#### How Has This Been Tested?

local nev

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.