### PR TITLE
[SELC-6181] feat: added API to retrieve manager info given onboardingId

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -3079,6 +3079,97 @@
         } ]
       }
     },
+    "/v1/users/onboarding/{onboardingId}/manager" : {
+      "get" : {
+        "tags" : [ "user" ],
+        "summary" : "getManagerInfo",
+        "description" : "Returns true if current manager and previous one are the same",
+        "operationId" : "checkManager_1",
+        "parameters" : [ {
+          "name" : "name",
+          "in" : "query",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "onboardingId",
+          "in" : "path",
+          "description" : "onboardingId",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ManagerInfoResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/v1/users/validate" : {
       "post" : {
         "tags" : [ "user" ],
@@ -4150,6 +4241,21 @@
           "reason" : {
             "type" : "string",
             "description" : "Invalid parameter reason."
+          }
+        }
+      },
+      "ManagerInfoResponse" : {
+        "title" : "ManagerInfoResponse",
+        "required" : [ "name", "surname" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "User's name"
+          },
+          "surname" : {
+            "type" : "string",
+            "description" : "User's surname"
           }
         }
       },

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/ManagerInfoResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/ManagerInfoResponse.java
@@ -1,0 +1,12 @@
+package it.pagopa.selfcare.onboarding.web.model;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+@Data
+public class ManagerInfoResponse {
+    @ApiModelProperty(value = "${swagger.onboarding.user.model.name}", required = true)
+    private String name;
+    @ApiModelProperty(value = "${swagger.onboarding.user.model.surname}", required = true)
+    private String surname;
+}

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/UserResourceMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/UserResourceMapper.java
@@ -1,0 +1,10 @@
+package it.pagopa.selfcare.onboarding.web.model.mapper;
+
+import it.pagopa.selfcare.onboarding.connector.model.onboarding.User;
+import it.pagopa.selfcare.onboarding.web.model.ManagerInfoResponse;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface UserResourceMapper {
+    ManagerInfoResponse toManagerInfoResponse(User user);
+}

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/UserControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/UserControllerTest.java
@@ -1,5 +1,7 @@
 package it.pagopa.selfcare.onboarding.web.controller;
 
+import it.pagopa.selfcare.commons.base.security.SelfCareUser;
+import it.pagopa.selfcare.commons.web.security.JwtAuthenticationToken;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
 import it.pagopa.selfcare.onboarding.core.UserService;
 import it.pagopa.selfcare.onboarding.core.exception.InvalidUserFieldsException;
@@ -7,6 +9,7 @@ import it.pagopa.selfcare.onboarding.web.config.WebTestConfig;
 import it.pagopa.selfcare.onboarding.web.handler.OnboardingExceptionHandler;
 import it.pagopa.selfcare.onboarding.web.model.OnboardingUserDto;
 import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapperImpl;
+import it.pagopa.selfcare.onboarding.web.model.mapper.UserResourceMapperImpl;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +22,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.security.Principal;
 
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
@@ -33,7 +38,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         UserController.class,
         OnboardingResourceMapperImpl.class,
         WebTestConfig.class,
-        OnboardingExceptionHandler.class
+        OnboardingExceptionHandler.class,
+        UserResourceMapperImpl.class
 })
 class UserControllerTest {
 
@@ -136,4 +142,28 @@ class UserControllerTest {
         verifyNoMoreInteractions(userServiceMock);
     }
 
+    /**
+     * Method under test: {@link UserController#getManagerInfo(String, Principal)}
+     */
+    @Test
+    void getManagerInfo() throws Exception {
+        //given
+        JwtAuthenticationToken mockPrincipal = Mockito.mock(JwtAuthenticationToken.class);
+        SelfCareUser selfCareUser = SelfCareUser.builder("example")
+                .fiscalCode("fiscalCode")
+                .build();
+        Mockito.when(mockPrincipal.getPrincipal()).thenReturn(selfCareUser);
+
+        // when
+        mvc.perform(MockMvcRequestBuilders
+                        .get(BASE_URL + "/onboarding/onboarding-test-id/manager")
+                        .principal(mockPrincipal)
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .accept(APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk());
+        // then
+        verify(userServiceMock, times(1))
+                .getManagerInfo(any(), any());
+        verifyNoMoreInteractions(userServiceMock);
+    }
 }


### PR DESCRIPTION
#### List of Changes

added API to retrieve manager info given onboardingId

#### Motivation and Context

This API is needed to find out the personal information of the manager who performed the membership of a given company on PNPG. In fact, internally it has control logics that allow the manager's personal data to be received in response, only if the user invoking the API is already ADMIN of the company or is LR on Infocamere and ADE registries.

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.