### PR TITLE
[SELC-6077] feat: return 404 in case product not found

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/ProductServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/ProductServiceImpl.java
@@ -2,14 +2,15 @@ package it.pagopa.selfcare.onboarding.core;
 
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.connector.api.ProductsConnector;
+import it.pagopa.selfcare.onboarding.connector.exceptions.ResourceNotFoundException;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.entity.ProductStatus;
+import it.pagopa.selfcare.product.exception.ProductNotFoundException;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -27,10 +28,14 @@ public class ProductServiceImpl implements ProductService {
         log.trace("getProduct start");
         log.debug("getProduct id = {}, institutionType = {}", id, institutionType);
         Assert.notNull(id, "ProductId is required");
-        Product product = productsConnector.getProduct(id, institutionType);
-        log.debug("getProduct result = {}", product);
-        log.trace("getProduct end");
-        return product;
+        try {
+            Product product = productsConnector.getProduct(id, institutionType);
+            log.debug("getProduct result = {}", product);
+            log.trace("getProduct end");
+            return product;
+        } catch (ProductNotFoundException e) {
+            throw new ResourceNotFoundException("No product found with id " + id);
+        }
     }
 
     @Override

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/ProductServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/ProductServiceImplTest.java
@@ -1,9 +1,15 @@
 package it.pagopa.selfcare.onboarding.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.connector.api.ProductsConnector;
+import it.pagopa.selfcare.onboarding.connector.exceptions.ResourceNotFoundException;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.entity.ProductStatus;
+import it.pagopa.selfcare.product.exception.ProductNotFoundException;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,8 +18,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class ProductServiceImplTest {
@@ -62,6 +66,23 @@ class ProductServiceImplTest {
         Product product = productService.getProduct(productId, institutionType);
         //then
         Assertions.assertSame(productMock, product);
+        Mockito.verify(productsConnectorMock, Mockito.times(1))
+                .getProduct(productId, institutionType);
+        Mockito.verifyNoMoreInteractions(productsConnectorMock);
+    }
+
+    @Test
+    void getProduct_NotFound() {
+        //given
+        final String productId = "productId";
+        InstitutionType institutionType = InstitutionType.PA;
+        Mockito.when(productsConnectorMock.getProduct(productId, institutionType))
+                .thenThrow(ProductNotFoundException.class);
+        //when
+        Executable executable = () -> productService.getProduct(productId, institutionType);
+        //then
+        ResourceNotFoundException e = assertThrows(ResourceNotFoundException.class, executable);
+        assertEquals("No product found with id " + productId, e.getMessage());
         Mockito.verify(productsConnectorMock, Mockito.times(1))
                 .getProduct(productId, institutionType);
         Mockito.verifyNoMoreInteractions(productsConnectorMock);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Changed the response for api v1/product/{productId} to 404 in case of product not found

#### Motivation and Context

If the productId passed in input does not exist, the API will return 404 as response.

#### How Has This Been Tested?

I have started the ms locally and tested both scenarios (with wrong and correct identifier)

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.