### PR TITLE
[SELC-6954] feat: Added api to retrieve uuid from PDV

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -972,6 +972,93 @@
         } ]
       }
     },
+    "/v1/users/search-user" : {
+      "post" : {
+        "tags" : [ "user-controller" ],
+        "summary" : "Returns uuid of specific user from PDV",
+        "description" : "Returns uuid of specific user from PDV",
+        "operationId" : "searchUserId",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UserTaxCodeDto"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "403" : {
+            "description" : "Forbidden",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserId"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "type" : "object",
+                  "description" : "Generic problem response"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "type" : "object",
+                  "description" : "Generic problem response"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "type" : "object",
+                  "description" : "Generic problem response"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "type" : "object",
+                  "description" : "Generic problem response"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/v1/users/onboarding" : {
       "post" : {
         "tags" : [ "user-controller" ],
@@ -3763,6 +3850,25 @@
           },
           "surname" : {
             "type" : "string"
+          }
+        }
+      },
+      "UserTaxCodeDto" : {
+        "required" : [ "taxCode" ],
+        "type" : "object",
+        "properties" : {
+          "taxCode" : {
+            "type" : "string"
+          }
+        }
+      },
+      "UserId" : {
+        "required" : [ "id" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "format" : "uuid"
           }
         }
       },

--- a/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/UserRegistryConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/onboarding/connector/api/UserRegistryConnector.java
@@ -21,4 +21,6 @@ public interface UserRegistryConnector {
 
     void deleteById(String userId);
 
+    UserId searchUser(String taxCode);
+
 }

--- a/connector/rest/docs/openapi/api-user-registry-docs.json
+++ b/connector/rest/docs/openapi/api-user-registry-docs.json
@@ -1,0 +1,596 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "pdv-u-user-registry-api",
+    "description" : "User Registry API documentation",
+    "version" : "1.0-SNAPSHOT"
+  },
+  "servers" : [ {
+    "url" : "https://api.uat.pdv.pagopa.it/{basePath}",
+    "variables" : {
+      "basePath" : {
+        "default" : "user-registry/v1"
+      }
+    }
+  } ],
+  "tags" : [ {
+    "name" : "user",
+    "description" : "User operations"
+  } ],
+  "paths" : {
+    "/users" : {
+      "patch" : {
+        "tags" : [ "user" ],
+        "summary" : "Upsert user",
+        "description" : "Update the given subset fields of an existing user by external id, if not present create a new one",
+        "operationId" : "saveUsingPATCH",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SaveUserDto"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserId"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too Many Requests",
+            "content" : { }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : { }
+          }
+        },
+        "security" : [ {
+          "api_key" : [ ]
+        } ]
+      }
+    },
+    "/users/{id}" : {
+      "get" : {
+        "tags" : [ "user" ],
+        "summary" : "Find user",
+        "description" : "Retrieve the user by its internal id",
+        "operationId" : "findByIdUsingGET",
+        "parameters" : [ {
+          "name" : "fl",
+          "in" : "query",
+          "description" : "Field list. Subset of fields to be retrieved for the requested resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "description" : "User internal id",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserResource"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too Many Requests",
+            "content" : { }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : { }
+          }
+        },
+        "security" : [ {
+          "api_key" : [ ]
+        } ]
+      },
+      "delete" : {
+        "tags" : [ "user" ],
+        "summary" : "Delete user",
+        "description" : "Delete the user by its internal id",
+        "operationId" : "deleteByIdUsingDELETE",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "User internal id",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "429" : {
+            "description" : "Too Many Requests",
+            "content" : { }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "No Content",
+            "content" : { }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : { }
+          }
+        },
+        "security" : [ {
+          "api_key" : [ ]
+        } ]
+      },
+      "patch" : {
+        "tags" : [ "user" ],
+        "summary" : "Update user",
+        "description" : "Update the given subset fields of an existing user by its internal id, if not present an error is returned",
+        "operationId" : "updateUsingPATCH",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "User internal id",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MutableUserFieldsDto"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "No Content",
+            "content" : { }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : { }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : { }
+          },
+          "429" : {
+            "description" : "Too Many Requests",
+            "content" : { }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "api_key" : [ ]
+        } ]
+      }
+    },
+    "/users/search" : {
+      "post" : {
+        "tags" : [ "user" ],
+        "summary" : "Search user",
+        "description" : "Search a user given its fiscal code",
+        "operationId" : "searchUsingPOST",
+        "parameters" : [ {
+          "name" : "fl",
+          "in" : "query",
+          "description" : "Field list. Subset of fields to be retrieved for the requested resource",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UserSearchDto"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserResource"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too Many Requests",
+            "content" : { }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : { }
+          }
+        },
+        "security" : [ {
+          "api_key" : [ ]
+        } ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "UserSearchDto" : {
+        "title" : "UserSearchDto",
+        "required" : [ "fiscalCode" ],
+        "type" : "object",
+        "properties" : {
+          "fiscalCode" : {
+            "type" : "string",
+            "description" : "User fiscal code"
+          }
+        }
+      },
+      "WorkContactResource" : {
+        "title" : "WorkContactResource",
+        "type" : "object",
+        "properties" : {
+          "email" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfstring"
+          }
+        }
+      },
+      "CertifiableFieldResourceOfstring" : {
+        "title" : "CertifiableFieldResourceOfstring",
+        "required" : [ "certification", "value" ],
+        "type" : "object",
+        "properties" : {
+          "certification" : {
+            "type" : "string",
+            "description" : "Certified source of information",
+            "enum" : [ "NONE", "SPID" ]
+          },
+          "value" : {
+            "type" : "string",
+            "description" : "Field value"
+          }
+        }
+      },
+      "UserId" : {
+        "title" : "UserId",
+        "required" : [ "id" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "User internal id",
+            "format" : "uuid"
+          }
+        }
+      },
+      "MutableUserFieldsDto" : {
+        "title" : "MutableUserFieldsDto",
+        "type" : "object",
+        "properties" : {
+          "birthDate" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfLocalDate"
+          },
+          "email" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfstring"
+          },
+          "familyName" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfstring"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfstring"
+          },
+          "workContacts" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/WorkContactResource"
+            },
+            "description" : "User work contacts"
+          }
+        }
+      },
+      "CertifiableFieldResourceOfLocalDate" : {
+        "title" : "CertifiableFieldResourceOfLocalDate",
+        "required" : [ "certification", "value" ],
+        "type" : "object",
+        "properties" : {
+          "certification" : {
+            "type" : "string",
+            "description" : "Certified source of information",
+            "enum" : [ "NONE", "SPID" ]
+          },
+          "value" : {
+            "type" : "string",
+            "description" : "Field value",
+            "format" : "date"
+          }
+        }
+      },
+      "UserResource" : {
+        "title" : "UserResource",
+        "required" : [ "id" ],
+        "type" : "object",
+        "properties" : {
+          "birthDate" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfLocalDate"
+          },
+          "email" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfstring"
+          },
+          "familyName" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfstring"
+          },
+          "fiscalCode" : {
+            "type" : "string",
+            "description" : "User fiscal code"
+          },
+          "id" : {
+            "type" : "string",
+            "description" : "User internal id",
+            "format" : "uuid"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfstring"
+          },
+          "workContacts" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/WorkContactResource"
+            },
+            "description" : "User work contacts"
+          }
+        }
+      },
+      "SaveUserDto" : {
+        "title" : "SaveUserDto",
+        "required" : [ "fiscalCode" ],
+        "type" : "object",
+        "properties" : {
+          "birthDate" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfLocalDate"
+          },
+          "email" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfstring"
+          },
+          "familyName" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfstring"
+          },
+          "fiscalCode" : {
+            "type" : "string",
+            "description" : "User fiscal code"
+          },
+          "name" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResourceOfstring"
+          },
+          "workContacts" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/WorkContactResource"
+            },
+            "description" : "User work contacts"
+          }
+        }
+      },
+      "Problem" : {
+        "title" : "Problem",
+        "required" : [ "status", "title" ],
+        "type" : "object",
+        "properties" : {
+          "detail" : {
+            "type" : "string",
+            "description" : "Human-readable description of this specific problem."
+          },
+          "instance" : {
+            "type" : "string",
+            "description" : "A URI that describes where the problem occurred."
+          },
+          "invalidParams" : {
+            "type" : "array",
+            "description" : "A list of invalid parameters details.",
+            "items" : {
+              "$ref" : "#/components/schemas/InvalidParam"
+            }
+          },
+          "status" : {
+            "type" : "integer",
+            "description" : "The HTTP status code.",
+            "format" : "int32"
+          },
+          "title" : {
+            "type" : "string",
+            "description" : "Short human-readable summary of the problem."
+          },
+          "type" : {
+            "type" : "string",
+            "description" : "A URL to a page with more details regarding the problem."
+          }
+        },
+        "description" : "A \"problem detail\" as a way to carry machine-readable details of errors (https://datatracker.ietf.org/doc/html/rfc7807)"
+      },
+      "InvalidParam" : {
+        "title" : "InvalidParam",
+        "required" : [ "name", "reason" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "Invalid parameter name."
+          },
+          "reason" : {
+            "type" : "string",
+            "description" : "Invalid parameter reason."
+          }
+        }
+      }
+    },
+    "securitySchemes" : {
+      "api_key" : {
+        "type" : "apiKey",
+        "name" : "x-api-key",
+        "in" : "header"
+      }
+    }
+  }
+}

--- a/connector/rest/pom.xml
+++ b/connector/rest/pom.xml
@@ -178,6 +178,38 @@
                             </configOptions>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>user-registry</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <inputSpec>${project.basedir}/docs/openapi/api-user-registry-docs.json</inputSpec>
+                            <generatorName>spring</generatorName>
+                            <library>spring-cloud</library>
+                            <modelNameSuffix />
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <configOptions>
+                                <useSpringBoot3>true</useSpringBoot3>
+                                <generateForOpenFeign>true</generateForOpenFeign>
+                                <basePackage>${project.groupId}.user_registry.generated.openapi.v1</basePackage>
+                                <modelPackage>${project.groupId}.user_registry.generated.openapi.v1.dto</modelPackage>
+                                <apiPackage>${project.groupId}.user_registry.generated.openapi.v1.api</apiPackage>
+                                <configPackage>${project.groupId}.user_registry.generated.openapi.v1.config</configPackage>
+                                <additionalModelTypeAnnotations>@lombok.Builder; @lombok.NoArgsConstructor; @lombok.AllArgsConstructor</additionalModelTypeAnnotations>
+                                <dateLibrary>java8-localdatetime</dateLibrary>
+                                <delegatePattern>true</delegatePattern>
+                                <interfaceOnly>true</interfaceOnly>
+                                <annotationLibrary>none</annotationLibrary>
+                                <documentationProvider>source</documentationProvider>
+                                <openApiNullable>false</openApiNullable>
+                                <skipDefaultInterface>false</skipDefaultInterface>
+                                <useTags>true</useTags>
+                            </configOptions>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/UserRegistryConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/UserRegistryConnectorImpl.java
@@ -8,7 +8,9 @@ import it.pagopa.selfcare.onboarding.connector.model.user.SaveUserDto;
 import it.pagopa.selfcare.onboarding.connector.model.user.User;
 import it.pagopa.selfcare.onboarding.connector.model.user.UserId;
 import it.pagopa.selfcare.onboarding.connector.rest.client.UserRegistryRestClient;
+import it.pagopa.selfcare.onboarding.connector.rest.mapper.UserMapper;
 import it.pagopa.selfcare.onboarding.connector.rest.model.user_registry.EmbeddedExternalId;
+import it.pagopa.selfcare.user_registry.generated.openapi.v1.dto.UserSearchDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -23,10 +25,13 @@ import java.util.UUID;
 public class UserRegistryConnectorImpl implements UserRegistryConnector {
 
     private final UserRegistryRestClient restClient;
+    public static final String USERS_FIELD_LIST = "fiscalCode,familyName,name,workContacts";
+    private final UserMapper userRegistryMapper;
 
     @Autowired
-    public UserRegistryConnectorImpl(UserRegistryRestClient restClient) {
+    public UserRegistryConnectorImpl(UserRegistryRestClient restClient, UserMapper userRegistryMapper) {
         this.restClient = restClient;
+        this.userRegistryMapper = userRegistryMapper;
     }
 
     @Override
@@ -85,6 +90,16 @@ public class UserRegistryConnectorImpl implements UserRegistryConnector {
         Assert.hasText(userId, "A UUID is required");
         restClient.deleteById(UUID.fromString(userId));
         log.trace("deleteById end");
+    }
+
+    @Override
+    public UserId searchUser(String taxCode) {
+        log.trace("searchUser start");
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "searchUser taxCode = {}}", taxCode);
+        UserId userId = userRegistryMapper.toUserId(restClient._searchUsingPOST(USERS_FIELD_LIST, new UserSearchDto().fiscalCode(taxCode)).getBody());
+        log.debug("searchUser result = {}", userId);
+        log.trace("searchUser end");
+        return userId;
     }
 
 

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/client/UserRegistryRestClient.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/client/UserRegistryRestClient.java
@@ -6,6 +6,7 @@ import it.pagopa.selfcare.onboarding.connector.model.user.User;
 import it.pagopa.selfcare.onboarding.connector.model.user.UserId;
 import it.pagopa.selfcare.onboarding.connector.rest.config.FeignClientConfig;
 import it.pagopa.selfcare.onboarding.connector.rest.model.user_registry.EmbeddedExternalId;
+import it.pagopa.selfcare.user_registry.generated.openapi.v1.api.UserApi;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -14,7 +15,7 @@ import java.util.EnumSet;
 import java.util.UUID;
 
 @FeignClient(name = "${rest-client.user-registry.serviceCode}", url = "${rest-client.user-registry.base-url}", configuration = FeignClientConfig.class)
-public interface UserRegistryRestClient {
+public interface UserRegistryRestClient extends UserApi {
 
     @PostMapping(value = "${rest-client.user-registry.getUserByExternalId.path}", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody

--- a/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/UserMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/onboarding/connector/rest/mapper/UserMapper.java
@@ -1,0 +1,14 @@
+package it.pagopa.selfcare.onboarding.connector.rest.mapper;
+
+import it.pagopa.selfcare.onboarding.connector.model.user.UserId;
+import it.pagopa.selfcare.user_registry.generated.openapi.v1.dto.UserResource;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+
+    @Mapping(source = "userResource.id", target = "id")
+    UserId toUserId(UserResource userResource);
+
+}

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/UserRegistryConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/UserRegistryConnectorImplTest.java
@@ -8,13 +8,10 @@ import it.pagopa.selfcare.onboarding.connector.rest.mapper.UserMapper;
 import it.pagopa.selfcare.onboarding.connector.rest.model.user_registry.EmbeddedExternalId;
 import it.pagopa.selfcare.user_registry.generated.openapi.v1.dto.UserResource;
 import it.pagopa.selfcare.user_registry.generated.openapi.v1.dto.UserSearchDto;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
@@ -36,12 +33,8 @@ class UserRegistryConnectorImplTest {
     @Mock
     private UserMapper userMapper;
 
+    @InjectMocks
     private UserRegistryConnectorImpl userConnector;
-
-    @BeforeEach
-    void setUp() {
-        userConnector = new UserRegistryConnectorImpl(restClientMock, userMapper);
-    }
 
     @Test
     void search_nullInfo() {

--- a/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/UserRegistryConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/onboarding/connector/UserRegistryConnectorImplTest.java
@@ -277,7 +277,6 @@ class UserRegistryConnectorImplTest {
     @Test
     void updateUser() {
         //given
-        String institutionId = "institutionId";
         UUID id = UUID.randomUUID();
         MutableUserFieldsDto userDto = TestUtils.mockInstance(new MutableUserFieldsDto(), "setWorkContacts");
         //when
@@ -287,7 +286,6 @@ class UserRegistryConnectorImplTest {
         ArgumentCaptor<MutableUserFieldsDto> userDtoCaptor = ArgumentCaptor.forClass(MutableUserFieldsDto.class);
         verify(restClientMock, Mockito.times(1))
                 .patchUser(any(), userDtoCaptor.capture());
-        MutableUserFieldsDto request = userDtoCaptor.getValue();
 
         Mockito.verifyNoMoreInteractions(restClientMock);
     }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/UserService.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/UserService.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.onboarding.core;
 
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.User;
+import it.pagopa.selfcare.onboarding.connector.model.user.UserId;
 
 public interface UserService {
   void validate(User user);
@@ -15,4 +16,6 @@ public interface UserService {
   User getManagerInfo(String onboardingId, String userTaxCode);
 
   boolean isAllowedUserByUid(String uid);
+
+  UserId searchUser(String taxCode);
 }

--- a/core/src/main/java/it/pagopa/selfcare/onboarding/core/UserServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/onboarding/core/UserServiceImpl.java
@@ -14,6 +14,7 @@ import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.User;
 import it.pagopa.selfcare.onboarding.connector.model.user.Certification;
 import it.pagopa.selfcare.onboarding.connector.model.user.CertifiedField;
+import it.pagopa.selfcare.onboarding.connector.model.user.UserId;
 import it.pagopa.selfcare.onboarding.core.exception.InvalidUserFieldsException;
 import it.pagopa.selfcare.onboarding.core.exception.OnboardingNotAllowedException;
 import it.pagopa.selfcare.onboarding.core.strategy.UserAllowedValidationStrategy;
@@ -142,4 +143,13 @@ public class UserServiceImpl implements UserService {
       log.trace("isAllowedUser for {}", uid);
       return userAllowedValidationStrategy.isAuthorizedUser(uid);
   }
+
+    @Override
+    public UserId searchUser(String taxCode) {
+        log.trace("searchUser start");
+        log.debug("searchUser taxCode = {}", taxCode);
+        UserId userId = userRegistryConnector.searchUser(taxCode);
+        log.trace("searchUser end");
+        return userId;
+    }
 }

--- a/core/src/test/java/it/pagopa/selfcare/onboarding/core/UserServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/onboarding/core/UserServiceImplTest.java
@@ -15,6 +15,7 @@ import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.User;
 import it.pagopa.selfcare.onboarding.connector.model.user.Certification;
 import it.pagopa.selfcare.onboarding.connector.model.user.CertifiedField;
+import it.pagopa.selfcare.onboarding.connector.model.user.UserId;
 import it.pagopa.selfcare.onboarding.core.exception.InvalidUserFieldsException;
 import it.pagopa.selfcare.onboarding.core.exception.OnboardingNotAllowedException;
 import it.pagopa.selfcare.onboarding.core.strategy.UserAllowedValidationStrategy;
@@ -22,6 +23,8 @@ import it.pagopa.selfcare.onboarding.core.utils.PgManagerVerifier;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
@@ -328,4 +331,23 @@ class UserServiceImplTest {
     // then
     assertTrue(result);
   }
+
+    @Test
+    void searchUser_returnsUserId_whenValidTaxCode() {
+        // given
+        String taxCode = "ABCDEF12G34H567I";
+        UUID uuid = UUID.randomUUID();
+        UserId userId = new UserId();
+        userId.setId(uuid);
+
+        when(userRegistryConnectorMock.searchUser(taxCode)).thenReturn(userId);
+
+        // when
+        UserId result = userService.searchUser(taxCode);
+
+        // then
+        assertNotNull(result);
+        assertEquals(userId, result);
+        verify(userRegistryConnectorMock).searchUser(taxCode);
+    }
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/controller/UserController.java
@@ -11,11 +11,9 @@ import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.commons.web.model.Problem;
 import it.pagopa.selfcare.commons.web.security.JwtAuthenticationToken;
+import it.pagopa.selfcare.onboarding.connector.model.user.UserId;
 import it.pagopa.selfcare.onboarding.core.UserService;
-import it.pagopa.selfcare.onboarding.web.model.CheckManagerResponse;
-import it.pagopa.selfcare.onboarding.web.model.ManagerInfoResponse;
-import it.pagopa.selfcare.onboarding.web.model.OnboardingUserDto;
-import it.pagopa.selfcare.onboarding.web.model.UserDataValidationDto;
+import it.pagopa.selfcare.onboarding.web.model.*;
 import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapper;
 import it.pagopa.selfcare.onboarding.web.model.mapper.UserMapper;
 import it.pagopa.selfcare.onboarding.web.model.mapper.UserResourceMapper;
@@ -134,5 +132,22 @@ public class UserController {
         ManagerInfoResponse managerInfoResponse = userResourceMapper.toManagerInfoResponse(userService.getManagerInfo(onboardingId, selfCareUser.getFiscalCode()));
         log.trace("getManagerInfo end");
         return managerInfoResponse;
+    }
+
+    @ApiResponse(responseCode = "403",
+            description = "Forbidden",
+            content = {
+                    @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE,
+                            schema = @Schema(implementation = Problem.class))
+            })
+    @PostMapping(value = "/search-user")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "${swagger.onboarding.users.api.search-user}",
+            description = "${swagger.onboarding.users.api.search-user}", operationId = "searchUserId")
+    public UserId searchUser(@RequestBody @Valid UserTaxCodeDto request) {
+        log.trace("searchUser start");
+        UserId userId =  userService.searchUser(userResourceMapper.toString(request));
+        log.trace("searchUser end");
+        return userId;
     }
 }

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/UserTaxCodeDto.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/UserTaxCodeDto.java
@@ -1,0 +1,16 @@
+package it.pagopa.selfcare.onboarding.web.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class UserTaxCodeDto {
+
+    @ApiModelProperty(value = "${swagger.onboarding.user.model.fiscalCode}", required = true)
+    @JsonProperty(required = true)
+    @NotBlank
+    private String taxCode;
+
+}

--- a/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/UserResourceMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/onboarding/web/model/mapper/UserResourceMapper.java
@@ -2,9 +2,14 @@ package it.pagopa.selfcare.onboarding.web.model.mapper;
 
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.User;
 import it.pagopa.selfcare.onboarding.web.model.ManagerInfoResponse;
+import it.pagopa.selfcare.onboarding.web.model.UserTaxCodeDto;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface UserResourceMapper {
     ManagerInfoResponse toManagerInfoResponse(User user);
+
+    default String toString(UserTaxCodeDto userTaxCode) {
+        return userTaxCode != null ? userTaxCode.getTaxCode() : null;
+    }
 }

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -101,6 +101,7 @@ swagger.onboarding.user.api.validate=Check if requested user data are valid
 swagger.onboarding.users.api.onboarding=The service allows the onboarding of Users
 swagger.onboarding.users.api.onboarding-aggregator=The service allows the onboarding of Users for aggregators
 swagger.onboarding.users.api.check-manager=Returns true if current manager and previous one are the same
+swagger.onboarding.users.api.search-user=Returns uuid of specific user from PDV
 swagger.onboarding.user.model.id=User's unique identifier
 swagger.onboarding.user.model.surname=User's surname
 swagger.onboarding.user.model.name=User's name

--- a/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/UserControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/onboarding/web/controller/UserControllerTest.java
@@ -1,14 +1,18 @@
 package it.pagopa.selfcare.onboarding.web.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.commons.web.security.JwtAuthenticationToken;
 import it.pagopa.selfcare.onboarding.connector.model.onboarding.OnboardingData;
+import it.pagopa.selfcare.onboarding.connector.model.user.UserId;
 import it.pagopa.selfcare.onboarding.core.UserService;
 import it.pagopa.selfcare.onboarding.core.exception.InvalidUserFieldsException;
 import it.pagopa.selfcare.onboarding.web.config.WebTestConfig;
 import it.pagopa.selfcare.onboarding.web.handler.OnboardingExceptionHandler;
 import it.pagopa.selfcare.onboarding.web.model.OnboardingUserDto;
+import it.pagopa.selfcare.onboarding.web.model.UserTaxCodeDto;
 import it.pagopa.selfcare.onboarding.web.model.mapper.OnboardingResourceMapperImpl;
+import it.pagopa.selfcare.onboarding.web.model.mapper.UserResourceMapper;
 import it.pagopa.selfcare.onboarding.web.model.mapper.UserResourceMapperImpl;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -24,6 +28,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.security.Principal;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
@@ -51,6 +56,10 @@ class UserControllerTest {
     @MockBean
     protected UserService userServiceMock;
 
+    @MockBean
+    private UserResourceMapper userResourceMapper;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     void validate_OK(@Value("classpath:stubs/userDataValidationDto.json") Resource userDataValidationDto) throws Exception {
@@ -166,4 +175,32 @@ class UserControllerTest {
                 .getManagerInfo(any(), any());
         verifyNoMoreInteractions(userServiceMock);
     }
+
+    @Test
+    void searchUser_returnsUserId_whenValidRequest() throws Exception {
+        // given
+        UserTaxCodeDto requestDto = new UserTaxCodeDto();
+        requestDto.setTaxCode("ABCDEF12G34H567I");
+
+        String taxCodeAsString = "ABCDEF12G34H567I";
+        UUID uuid = UUID.randomUUID();
+        UserId userId = new UserId();
+        userId.setId(uuid);
+
+        when(userResourceMapper.toString(requestDto)).thenReturn(taxCodeAsString);
+        when(userServiceMock.searchUser(taxCodeAsString)).thenReturn(userId);
+
+        // when
+        mvc.perform(MockMvcRequestBuilders
+                        .post(BASE_URL+ "/search-user")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(userId)));
+
+        // then
+        verify(userResourceMapper).toString(requestDto);
+        verify(userServiceMock).searchUser(taxCodeAsString);
+    }
+
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added api to retrieve uuid from PDV
- added open api generator for PDV

#### Motivation and Context

This API returns the user's uuid during the onboarding phase that will be used later by the already implemented check-manager. If the API returns 404 (not present on PDV) the second call will not be made

#### How Has This Been Tested?

MS was started locally and the API was invoked to see if everything was working correctly

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.